### PR TITLE
Add delay before test assertion on Nurego

### DIFF
--- a/acs-integration-tests/src/test/java/com/ge/predix/integration/test/ACSMeteringIT.java
+++ b/acs-integration-tests/src/test/java/com/ge/predix/integration/test/ACSMeteringIT.java
@@ -129,6 +129,8 @@ public class ACSMeteringIT extends AbstractTestNGSpringContextTests {
             System.out.println("POLICY UPDATE USAGE AFTER:" + afterPolicyUpdateMeterCount);
             System.out.println("POLICY EVAL USAGE AFTER:" + afterPolicyEvalMeterCount);
 
+            //Nurego server seems to have a lag before the counts are updated
+            Thread.sleep(2000);
             // Assert metering counts incremented by 1
             Assert.assertEquals(afterPolicyUpdateMeterCount - beforePolicyUpdateMeterCount, 1.0);
             Assert.assertEquals(afterPolicyEvalMeterCount - beforePolicyEvalMeterCount, 1.0);


### PR DESCRIPTION
sample failure due to timing - http://sjc1jenkins08.crd.ge.com:8080/job/Predix-Security/job/acs-integration-develop/958/testReport/
