### PR TITLE
US9933:  Add message property to PolicyEvaluationResult and return a valid error when traversal limit exceeded

### DIFF
--- a/model/src/main/java/com/ge/predix/acs/rest/PolicyEvaluationResult.java
+++ b/model/src/main/java/com/ge/predix/acs/rest/PolicyEvaluationResult.java
@@ -55,6 +55,8 @@ public class PolicyEvaluationResult {
 
     private long timestamp;
 
+    private String message;
+
     public PolicyEvaluationResult() {
         this.effect = Effect.NOT_APPLICABLE;
     }
@@ -122,5 +124,13 @@ public class PolicyEvaluationResult {
     public String toString() {
         return "PolicyEvaluationResult [effect=" + this.effect + ", subjectAttributes=" + this.subjectAttributes
                 + ", resourceAttributes=" + this.resourceAttributes + "]";
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
     }
 }

--- a/service/src/main/java/com/ge/predix/acs/privilege/management/dao/AttributeLimitExceededException.java
+++ b/service/src/main/java/com/ge/predix/acs/privilege/management/dao/AttributeLimitExceededException.java
@@ -1,0 +1,14 @@
+package com.ge.predix.acs.privilege.management.dao;
+
+public class AttributeLimitExceededException extends RuntimeException {
+
+    private static final long serialVersionUID = -9111322155771470957L;
+
+    public AttributeLimitExceededException() {
+        super();
+    }
+
+    public AttributeLimitExceededException(final String message) {
+        super(message);
+    }
+}

--- a/service/src/main/java/com/ge/predix/acs/privilege/management/dao/GraphGenericRepository.java
+++ b/service/src/main/java/com/ge/predix/acs/privilege/management/dao/GraphGenericRepository.java
@@ -35,7 +35,6 @@ import com.ge.predix.acs.rest.Parent;
 import com.ge.predix.acs.utils.JsonUtils;
 import com.ge.predix.acs.zone.management.dao.ZoneEntity;
 import com.google.common.collect.Sets;
-import com.thinkaurelius.titan.core.QueryException;
 import com.thinkaurelius.titan.core.SchemaViolationException;
 
 public abstract class GraphGenericRepository<E extends ZonableEntity> implements JpaRepository<E, Long> {
@@ -402,7 +401,7 @@ public abstract class GraphGenericRepository<E extends ZonableEntity> implements
                         attributes.addAll(deserializedAttributes);
                         // This enforces the limit on the count of attributes returned from the traversal, instead of
                         // number of vertices traversed. To do the latter will require traversing the graph twice.
-                        checkTraversalLimitOrFail(attributes);
+                        checkTraversalLimitOrFail(entity, attributes);
                     }
                 });
 
@@ -415,16 +414,18 @@ public abstract class GraphGenericRepository<E extends ZonableEntity> implements
                             Attribute.class);
                     if (deserializedAttributes != null) {
                         attributes.addAll(deserializedAttributes);
-                        checkTraversalLimitOrFail(attributes);
+                        checkTraversalLimitOrFail(entity, attributes);
                     }
                 });
         entity.setAttributes(attributes);
         entity.setAttributesAsJson(JSON_UTILS.serialize(attributes));
     }
 
-    private void checkTraversalLimitOrFail(final Set<Attribute> attributes) {
+    private void checkTraversalLimitOrFail(final E e, final Set<Attribute> attributes) {
         if (attributes.size() > this.traversalLimit) {
-            throw new QueryException("Graph search failed: traversal limit exceeded.");
+            String exceptionMessage = String.format("The number of attributes on this " + e.getEntityType() + " '"
+                    + e.getEntityId() + "' has exceeded the maximum limit of %d", this.traversalLimit);
+            throw new AttributeLimitExceededException(exceptionMessage);
         }
     }
 

--- a/service/src/main/java/com/ge/predix/acs/privilege/management/dao/ResourceEntity.java
+++ b/service/src/main/java/com/ge/predix/acs/privilege/management/dao/ResourceEntity.java
@@ -164,4 +164,14 @@ public class ResourceEntity implements ZonableEntity {
         }
         return false;
     }
+
+    @Override
+    public String getEntityId() {
+        return this.getResourceIdentifier();
+    }
+
+    @Override
+    public String getEntityType() {
+        return "resource";
+    }
 }

--- a/service/src/main/java/com/ge/predix/acs/privilege/management/dao/SubjectEntity.java
+++ b/service/src/main/java/com/ge/predix/acs/privilege/management/dao/SubjectEntity.java
@@ -169,4 +169,14 @@ public class SubjectEntity implements ZonableEntity {
         }
         return false;
     }
+
+    @Override
+    public String getEntityId() {
+        return this.getSubjectIdentifier();
+    }
+
+    @Override
+    public String getEntityType() {
+        return "subject";
+    }
 }

--- a/service/src/main/java/com/ge/predix/acs/privilege/management/dao/ZonableEntity.java
+++ b/service/src/main/java/com/ge/predix/acs/privilege/management/dao/ZonableEntity.java
@@ -9,6 +9,10 @@ import com.ge.predix.acs.zone.management.dao.ZoneEntity;
 public interface ZonableEntity {
     Long getId();
 
+    String getEntityId();
+
+    String getEntityType();
+
     void setId(Long id);
 
     ZoneEntity getZone();

--- a/service/src/test/java/com/ge/predix/acs/privilege/management/dao/GraphResourceRepositoryTest.java
+++ b/service/src/test/java/com/ge/predix/acs/privilege/management/dao/GraphResourceRepositoryTest.java
@@ -50,7 +50,6 @@ import com.ge.predix.acs.model.Attribute;
 import com.ge.predix.acs.rest.Parent;
 import com.ge.predix.acs.utils.JsonUtils;
 import com.ge.predix.acs.zone.management.dao.ZoneEntity;
-import com.thinkaurelius.titan.core.QueryException;
 import com.thinkaurelius.titan.core.SchemaViolationException;
 import com.thinkaurelius.titan.core.TitanFactory;
 
@@ -397,8 +396,8 @@ public class GraphResourceRepositoryTest {
     }
 
     @Test(
-            expectedExceptions = QueryException.class,
-            expectedExceptionsMessageRegExp = "Graph search failed: traversal limit exceeded.")
+            expectedExceptions = AttributeLimitExceededException.class,
+            expectedExceptionsMessageRegExp = "The number of attributes on this resource .* has exceeded the maximum limit of .*")
     public void testSearchAttributesTraversalLimitException() {
         long traversalLimit = 256L;
         try {

--- a/service/src/test/java/com/ge/predix/acs/testutils/XFiles.java
+++ b/service/src/test/java/com/ge/predix/acs/testutils/XFiles.java
@@ -113,6 +113,19 @@ public final class XFiles {
         return Arrays.asList(new BaseResource[] { pentagon, ascension, evidenceImplant });
     }
 
+    public static List<BaseResource> createTwoLevelResourceHierarchy() {
+
+        BaseResource basement = new BaseResource(BASEMENT_SITE_ID);
+        basement.setAttributes(BASEMENT_ATTRIBUTES);
+
+        BaseResource scullysTestimony = new BaseResource(EVIDENCE_SCULLYS_TESTIMONY_ID);
+        scullysTestimony.setAttributes(SCULLYS_TESTIMONY_ATTRIBUTES);
+        scullysTestimony.setParents(new HashSet<>(Arrays.asList(new Parent[] {
+                new Parent(basement.getResourceIdentifier())})));
+
+        return Arrays.asList(new BaseResource[] { basement, scullysTestimony });
+    }
+
     public static List<BaseResource> createThreeLevelResourceHierarchy() {
         BaseResource basement = new BaseResource(BASEMENT_SITE_ID);
         basement.setAttributes(BASEMENT_ATTRIBUTES);


### PR DESCRIPTION
US9933: Add message property to PolicyEvaluationResult and return a valid error when traversal limit exceeded
- Added test assertion for the expected message when traversal limit is exceeded
- Added test case with subject attribute exceeding limit. Also, added travelsal limit to error message
- Reset Traversal limit at the end of the test

Signed-off-by: Matias Altman matias.altman@ge.com
