### PR TITLE
US45006: Make subject attributes consistent

### DIFF
--- a/acs-integration-tests/src/test/java/com/ge/predix/acceptance/test/policy/evaluation/PolicyEvaluationStepsDefinitions.java
+++ b/acs-integration-tests/src/test/java/com/ge/predix/acceptance/test/policy/evaluation/PolicyEvaluationStepsDefinitions.java
@@ -26,6 +26,7 @@ import static com.ge.predix.test.utils.PrivilegeHelper.DEFAULT_SUBJECT_IDENTIFIE
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -187,7 +188,7 @@ public class PolicyEvaluationStepsDefinitions extends AbstractTestNGSpringContex
     @When("^Evaluation request which has the subject attribute role with the value (.*)$")
     public void evaluationRequestWithSubjectAttribute(final String subjectAttribute) throws Throwable {
 
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = new HashSet<Attribute>();
         subjectAttributes.add(new Attribute(DEFAULT_ATTRIBUTE_ISSUER, "role", subjectAttribute));
         this.policyEvaluationResponse = this.policyHelper.sendEvaluationRequest(this.acsAdminRestTemplate,
                 this.policyHelper.createEvalRequest(DEFAULT_ACTION, DEFAULT_SUBJECT_ID, DEFAULT_RESOURCE_IDENTIFIER,
@@ -198,7 +199,7 @@ public class PolicyEvaluationStepsDefinitions extends AbstractTestNGSpringContex
     public void evaluationRequestForResourceWithSubjectAttribute(final String resourceIdentifier,
             final String attributeName, final String attributeValue) throws Throwable {
 
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = new HashSet<Attribute>();
         subjectAttributes.add(new Attribute(DEFAULT_ATTRIBUTE_ISSUER, attributeName, attributeValue));
         this.policyEvaluationResponse = this.policyHelper.sendEvaluationRequest(this.acsAdminRestTemplate,
                 this.policyHelper.createEvalRequest(DEFAULT_ACTION, DEFAULT_SUBJECT_ID, resourceIdentifier,
@@ -222,7 +223,7 @@ public class PolicyEvaluationStepsDefinitions extends AbstractTestNGSpringContex
 
     @When("^Evaluation request which has no subject attribute$")
     public void evaluation_request_which_has_no_subject_attribute() throws Throwable {
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = Collections.emptySet();
         this.policyEvaluationResponse = this.policyHelper.sendEvaluationRequest(this.acsAdminRestTemplate,
                 this.policyHelper.createEvalRequest(DEFAULT_ACTION, DEFAULT_SUBJECT_ID, DEFAULT_RESOURCE_IDENTIFIER,
                         subjectAttributes));
@@ -267,7 +268,7 @@ public class PolicyEvaluationStepsDefinitions extends AbstractTestNGSpringContex
 
     @When("^A policy evaluation is requested with any HTTP action$")
     public void a_policy_evaluation_is_requested_with_any_HTTP_action() throws Throwable {
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = Collections.emptySet();
         this.policyEvaluationResponse = this.policyHelper.sendEvaluationRequest(this.acsAdminRestTemplate,
                 this.policyHelper.createEvalRequest(DEFAULT_ACTION, DEFAULT_SUBJECT_ID, DEFAULT_RESOURCE_IDENTIFIER,
                         subjectAttributes));
@@ -275,7 +276,7 @@ public class PolicyEvaluationStepsDefinitions extends AbstractTestNGSpringContex
 
     @When("^A policy evaluation is requested with an HTTP action matching .*$")
     public void a_policy_evaluation_is_requested_with_an_HTTP_action_matching() throws Throwable {
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = Collections.emptySet();
         this.policyEvaluationResponse = this.policyHelper.sendEvaluationRequest(this.acsAdminRestTemplate,
                 this.policyHelper.createEvalRequest(DEFAULT_ACTION, DEFAULT_SUBJECT_ID, DEFAULT_RESOURCE_IDENTIFIER,
                         subjectAttributes));
@@ -283,7 +284,7 @@ public class PolicyEvaluationStepsDefinitions extends AbstractTestNGSpringContex
 
     @When("^A policy evaluation is requested with an HTTP action not matching .*$")
     public void a_policy_evaluation_is_requested_with_an_HTTP_action_not_matching() throws Throwable {
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = Collections.emptySet();
         this.policyEvaluationResponse = this.policyHelper.sendEvaluationRequest(this.acsAdminRestTemplate,
                 this.policyHelper.createEvalRequest(NOT_MATCHING_ACTION, DEFAULT_SUBJECT_ID,
                         DEFAULT_RESOURCE_IDENTIFIER, subjectAttributes));

--- a/acs-integration-tests/src/test/java/com/ge/predix/test/utils/PolicyHelper.java
+++ b/acs-integration-tests/src/test/java/com/ge/predix/test/utils/PolicyHelper.java
@@ -20,9 +20,9 @@ import static com.ge.predix.test.utils.ACSTestUtil.ACS_VERSION;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import java.util.Random;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
@@ -102,13 +102,13 @@ public class PolicyHelper {
 
     public PolicyEvaluationRequestV1 createRandomEvalRequest() {
         Random r = new Random(System.currentTimeMillis());
-        List<Attribute> subjectAttributes = new ArrayList<Attribute>();
+        Set<Attribute> subjectAttributes = Collections.emptySet();
         return this.createEvalRequest(ACTIONS[r.nextInt(4)], String.valueOf(r.nextLong()),
                 "/alarms/sites/" + String.valueOf(r.nextLong()), subjectAttributes);
     }
 
     public PolicyEvaluationRequestV1 createEvalRequest(final String action, final String subjectIdentifier,
-            final String resourceIdentifier, final List<Attribute> subjectAttributes) {
+            final String resourceIdentifier, final Set<Attribute> subjectAttributes) {
         PolicyEvaluationRequestV1 policyEvaluationRequest = new PolicyEvaluationRequestV1();
         policyEvaluationRequest.setAction(action);
         policyEvaluationRequest.setSubjectIdentifier(subjectIdentifier);

--- a/model/src/main/java/com/ge/predix/acs/rest/PolicyEvaluationRequestV1.java
+++ b/model/src/main/java/com/ge/predix/acs/rest/PolicyEvaluationRequestV1.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package com.ge.predix.acs.rest;
 
-import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -33,9 +33,9 @@ public class PolicyEvaluationRequestV1 {
 
     private String subjectIdentifier;
 
-    private List<Attribute> subjectAttributes;
+    private Set<Attribute> subjectAttributes;
 
-    private List<Attribute> resourceAttributes;
+    private Set<Attribute> resourceAttributes;
 
     private String action;
 
@@ -58,11 +58,11 @@ public class PolicyEvaluationRequestV1 {
     }
 
     @ApiModelProperty(value = "Supplemental resource attributes provided by the requestor")
-    public List<Attribute> getResourceAttributes() {
+    public Set<Attribute> getResourceAttributes() {
         return this.resourceAttributes;
     }
 
-    public void setResourceAttributes(final List<Attribute> resourceAttributes) {
+    public void setResourceAttributes(final Set<Attribute> resourceAttributes) {
         this.resourceAttributes = resourceAttributes;
     }
 
@@ -70,7 +70,7 @@ public class PolicyEvaluationRequestV1 {
      * @return the subjectAttributes
      */
     @ApiModelProperty(value = "Supplemental subject attributes provided by the requestor")
-    public List<Attribute> getSubjectAttributes() {
+    public Set<Attribute> getSubjectAttributes() {
         return this.subjectAttributes;
     }
 
@@ -78,7 +78,7 @@ public class PolicyEvaluationRequestV1 {
      * @param subjectAttributes
      *            the subjectAttributes to set
      */
-    public void setSubjectAttributes(final List<Attribute> subjectAttributes) {
+    public void setSubjectAttributes(final Set<Attribute> subjectAttributes) {
         this.subjectAttributes = subjectAttributes;
     }
 
@@ -119,9 +119,12 @@ public class PolicyEvaluationRequestV1 {
                 return false;
             }
             if ((null != this.subjectAttributes) && (this.subjectAttributes.size() == other.subjectAttributes.size())) {
-                for (int i = 0; i < this.subjectAttributes.size(); i++) {
-                    equalsBuilder.append(this.subjectAttributes.get(i), other.subjectAttributes.get(i));
-                }
+                // Element by element comparison may produce true negative in Sets so use built in equals
+                // From AbstractSet's (HashSet's ancestor) documentation
+                // This implementation first checks if the specified object is this set; if so it returns true.
+                // Then, it checks if the specified object is a set whose size is identical to the size of this set;
+                // if not, it returns false. If so, it returns containsAll((Collection) o).
+                equalsBuilder.append(this.subjectAttributes, other.subjectAttributes);
             }
             equalsBuilder.append(this.action, other.action).append(this.resourceIdentifier, other.resourceIdentifier)
                     .append(this.subjectIdentifier, other.subjectIdentifier);

--- a/model/src/main/java/com/ge/predix/acs/rest/PolicyEvaluationResult.java
+++ b/model/src/main/java/com/ge/predix/acs/rest/PolicyEvaluationResult.java
@@ -38,7 +38,7 @@ public class PolicyEvaluationResult {
     private Effect effect;
 
     @ApiModelProperty(value = "The collection of the subject's attributes", required = false)
-    private List<Attribute> subjectAttributes = Collections.emptyList();
+    private Set<Attribute> subjectAttributes = Collections.emptySet();
 
     @ApiModelProperty(value = "The collection of the resource's attributes", required = false)
     private List<Attribute> resourceAttributes = Collections.emptyList();
@@ -65,14 +65,14 @@ public class PolicyEvaluationResult {
         this.effect = decision;
     }
 
-    public PolicyEvaluationResult(final Effect effect, final List<Attribute> subjectAttributes,
+    public PolicyEvaluationResult(final Effect effect, final Set<Attribute> subjectAttributes,
             final List<Attribute> resourceAttributes) {
         this.effect = effect;
         this.subjectAttributes = subjectAttributes;
         this.resourceAttributes = resourceAttributes;
     }
 
-    public PolicyEvaluationResult(final Effect effect, final List<Attribute> subjectAttributes,
+    public PolicyEvaluationResult(final Effect effect, final Set<Attribute> subjectAttributes,
             final List<Attribute> resourceAttributes, final Set<String> resolvedResourceUris) {
         this.effect = effect;
         this.subjectAttributes = subjectAttributes;
@@ -88,11 +88,11 @@ public class PolicyEvaluationResult {
         this.effect = effect;
     }
 
-    public List<Attribute> getSubjectAttributes() {
+    public Set<Attribute> getSubjectAttributes() {
         return this.subjectAttributes;
     }
 
-    public void setSubjectAttributes(final List<Attribute> subjectAttributes) {
+    public void setSubjectAttributes(final Set<Attribute> subjectAttributes) {
         this.subjectAttributes = subjectAttributes;
     }
 

--- a/model/src/test/java/com/ge/predix/acs/rest/PolicyEvaluationRequestV1Test.java
+++ b/model/src/test/java/com/ge/predix/acs/rest/PolicyEvaluationRequestV1Test.java
@@ -17,6 +17,7 @@
 package com.ge.predix.acs.rest;
 
 import java.util.Arrays;
+import java.util.HashSet;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -46,14 +47,24 @@ public class PolicyEvaluationRequestV1Test {
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                new Attribute("issuer", "role"),
+                                new Attribute("issuer", "group")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertEquals(a, b);
     }
 
@@ -69,7 +80,12 @@ public class PolicyEvaluationRequestV1Test {
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertNotEquals(a, b);
     }
 
@@ -80,7 +96,12 @@ public class PolicyEvaluationRequestV1Test {
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
@@ -95,32 +116,24 @@ public class PolicyEvaluationRequestV1Test {
         a.setSubjectIdentifier("subject");
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
-        a.setSubjectAttributes(Arrays.asList(new Attribute[] { new Attribute("issuer", "role") }));
-
-        PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
-        b.setSubjectIdentifier("subject");
-        b.setAction("GET");
-        b.setResourceIdentifier("/resource");
-        b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
-        Assert.assertNotEquals(a, b);
-    }
-
-    @Test
-    public void testEqualsDifferentOrderAttributes() {
-        PolicyEvaluationRequestV1 a = new PolicyEvaluationRequestV1();
-        a.setSubjectIdentifier("subject");
-        a.setAction("GET");
-        a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "group"), new Attribute("issuer", "role") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertNotEquals(a, b);
     }
 
@@ -131,14 +144,24 @@ public class PolicyEvaluationRequestV1Test {
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "site") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "site")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertNotEquals(a, b);
     }
 
@@ -165,14 +188,23 @@ public class PolicyEvaluationRequestV1Test {
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(new Attribute[] {
+                                new Attribute("issuer", "role"),
+                                new Attribute("issuer", "group")
+                        })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertEquals(a.hashCode(), b.hashCode());
     }
 
@@ -188,7 +220,11 @@ public class PolicyEvaluationRequestV1Test {
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(new Attribute[] {
+                                new Attribute("issuer", "role"),
+                                new Attribute("issuer", "group")
+                        })));
         Assert.assertNotEquals(a.hashCode(), b.hashCode());
     }
 
@@ -199,7 +235,12 @@ public class PolicyEvaluationRequestV1Test {
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
@@ -214,32 +255,24 @@ public class PolicyEvaluationRequestV1Test {
         a.setSubjectIdentifier("subject");
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
-        a.setSubjectAttributes(Arrays.asList(new Attribute[] { new Attribute("issuer", "role") }));
-
-        PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
-        b.setSubjectIdentifier("subject");
-        b.setAction("GET");
-        b.setResourceIdentifier("/resource");
-        b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
-        Assert.assertNotEquals(a.hashCode(), b.hashCode());
-    }
-
-    @Test
-    public void testHashCodeDifferentOrderAttributes() {
-        PolicyEvaluationRequestV1 a = new PolicyEvaluationRequestV1();
-        a.setSubjectIdentifier("subject");
-        a.setAction("GET");
-        a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "group"), new Attribute("issuer", "role") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertNotEquals(a.hashCode(), b.hashCode());
     }
 
@@ -250,14 +283,24 @@ public class PolicyEvaluationRequestV1Test {
         a.setAction("GET");
         a.setResourceIdentifier("/resource");
         a.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "site") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "site")
+                                })));
 
         PolicyEvaluationRequestV1 b = new PolicyEvaluationRequestV1();
         b.setSubjectIdentifier("subject");
         b.setAction("GET");
         b.setResourceIdentifier("/resource");
         b.setSubjectAttributes(
-                Arrays.asList(new Attribute[] { new Attribute("issuer", "role"), new Attribute("issuer", "group") }));
+                new HashSet<Attribute>(
+                        Arrays.asList(
+                                new Attribute[] {
+                                        new Attribute("issuer", "role"),
+                                        new Attribute("issuer", "group")
+                                })));
         Assert.assertNotEquals(a.hashCode(), b.hashCode());
     }
 }

--- a/service/src/main/java/com/ge/predix/acs/service/policy/evaluation/PolicyEvaluationServiceImpl.java
+++ b/service/src/main/java/com/ge/predix/acs/service/policy/evaluation/PolicyEvaluationServiceImpl.java
@@ -202,7 +202,7 @@ public class PolicyEvaluationServiceImpl implements PolicyEvaluationService {
                     break;
                 }
             }
-            result = new PolicyEvaluationResult(effect, new ArrayList<>(subjectAttributes),
+            result = new PolicyEvaluationResult(effect, subjectAttributes,
                     new ArrayList<>(resourceAttributes), resolvedResourceUris);
         } catch (AttributeLimitExceededException ae) {
             result = handlePolicyEvaluationException(policySet, subjectIdentifier, resourceURI, ae);

--- a/service/src/test/java/com/ge/predix/controller/test/PolicyEvalWithGraphDbControllerIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/PolicyEvalWithGraphDbControllerIT.java
@@ -16,7 +16,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.net.URLEncoder;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -219,7 +221,7 @@ public class PolicyEvalWithGraphDbControllerIT extends AbstractTestNGSpringConte
                     .readValue(mvcResult.getResponse().getContentAsByteArray(), PolicyEvaluationResult.class);
             assertThat(policyEvalResult.getEffect(), equalTo(expectedEffect));
             assertThat(policyEvalResult.getMessage(), equalTo(expectedMessage));
-        } finally{
+        } finally {
             graphResourceRepository.setTraversalLimit(traversalLimit);
             graphSubjectRepository.setTraversalLimit(traversalLimit);
         }
@@ -274,14 +276,24 @@ public class PolicyEvalWithGraphDbControllerIT extends AbstractTestNGSpringConte
     Object[] evaluationWithSupplementalAttributesData() {
         return new Object[] { this.testZone1, this.policySet, null, null,
                 createPolicyEvalRequest("GET", EVIDENCE_IMPLANT_ID, AGENT_MULDER,
-                        Arrays.asList(new Attribute[] { SPECIAL_AGENTS_GROUP_ATTRIBUTE, TOP_SECRET_CLASSIFICATION }),
-                        Arrays.asList(new Attribute[] { SPECIAL_AGENTS_GROUP_ATTRIBUTE, TOP_SECRET_CLASSIFICATION })),
+                        new HashSet<Attribute>(
+                                Arrays.asList(
+                                        new Attribute[] {
+                                                SPECIAL_AGENTS_GROUP_ATTRIBUTE,
+                                                TOP_SECRET_CLASSIFICATION
+                                        })),
+                        new HashSet<Attribute>(
+                                Arrays.asList(
+                                        new Attribute[] {
+                                                SPECIAL_AGENTS_GROUP_ATTRIBUTE,
+                                                TOP_SECRET_CLASSIFICATION
+                                        }))),
                 Effect.PERMIT };
     }
 
     /**
-     * Test that evaluation is successful when the resource and/or subject attributes exceed the length. The policy set will return
-     * indeterminate because the traversal limit is exceeded.
+     * Test that evaluation is successful when the resource and/or subject attributes exceed the length.
+     * The policy set will return indeterminate because the traversal limit is exceeded.
      */
     Object[] evaluationWithResourceAttributesExceedingTraversalLimitData() {
         String errorMessage = "The number of attributes on this resource '"
@@ -313,8 +325,8 @@ public class PolicyEvalWithGraphDbControllerIT extends AbstractTestNGSpringConte
     }
 
     PolicyEvaluationRequestV1 createPolicyEvalRequest(final String action, final String resourceIdentifier,
-            final String subjectIdentifier, final List<Attribute> supplementalResourceAttributes,
-            final List<Attribute> supplementalSubjectAttributes) {
+            final String subjectIdentifier, final Set<Attribute> supplementalResourceAttributes,
+            final Set<Attribute> supplementalSubjectAttributes) {
         PolicyEvaluationRequestV1 policyEvalRequest = new PolicyEvaluationRequestV1();
         policyEvalRequest.setAction("GET");
         policyEvalRequest.setResourceIdentifier(resourceIdentifier);


### PR DESCRIPTION
- Modified PolicyEvaluationRequestV1Test.java to reflect Set is unordered
- Modified PolicyEvaluationRequestV1 so that subjectAttributes and resourceAttributes are sets instead of list
- Modified PolicyEvaluationRequestV1 so that functions reflect Subject/ResourceAttributes are sets instead of list
- Modified Unit tests that failed to compile due to the changes to PolicyEval
- Modified Integration tests to reflect new changes
