### PR TITLE
US47429: Graceful fail on set parents on non-titan profile

### DIFF
--- a/acs-integration-tests/pom.xml
+++ b/acs-integration-tests/pom.xml
@@ -242,6 +242,7 @@
                             <excludes>
                                 <exclude>**/ACSPerformanceIT.java</exclude>
                                 <exclude>**/PolicyEvalCachingWithGraphDBIT.java</exclude>
+                                <exclude>**/Hierarchical*IT.java</exclude>
                             </excludes>
                             <includes>
                                 <include>**/*IT.java</include>
@@ -402,6 +403,7 @@
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/ACSPerformanceIT.java</exclude>
+                                <exclude>**/NonHierarchical*IT.java</exclude>
                             </excludes>
                             <includes>
                                 <include>**/*IT.java</include>
@@ -552,6 +554,7 @@
                             <excludes>
                                 <exclude>**/ACSPerformanceIT.java</exclude>
                                 <exclude>**/PolicyEvalCachingWithGraphDBIT.java</exclude>
+                                <exclude>**/NonHierarchical*IT.java</exclude>
                             </excludes>
                             <includes>
                                 <include>**/*IT.java</include>
@@ -669,6 +672,9 @@
                             <suiteXmlFiles>
                                 <suiteXmlFile>testng-public.xml</suiteXmlFile>
                             </suiteXmlFiles>
+                            <excludes>
+                                <exclude>**/Hierarchical*IT.java</exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>
@@ -774,6 +780,9 @@
                             <suiteXmlFiles>
                                 <suiteXmlFile>testng-public-titan.xml</suiteXmlFile>
                             </suiteXmlFiles>
+                            <excludes>
+                                <exclude>**/NonHierarchical*IT.java</exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>
@@ -841,6 +850,9 @@
                             <includes>
                                 <include>**/ACSAcceptanceIT.java</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/NonHierarchical*IT.java</exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>

--- a/commons/src/main/java/com/ge/predix/acs/commons/web/BaseRestApi.java
+++ b/commons/src/main/java/com/ge/predix/acs/commons/web/BaseRestApi.java
@@ -15,12 +15,14 @@
  *******************************************************************************/
 package com.ge.predix.acs.commons.web;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Base class for REST Apis that provides common error handler.
@@ -29,9 +31,17 @@ import org.springframework.web.servlet.ModelAndView;
  *
  */
 public class BaseRestApi {
+    public static final String PARENTS_ATTR_NOT_SUPPORTED_MSG = "The parents attribute isn't supported yet";
 
     @Autowired
     private RestErrorHandler restErrorHandler;
+
+    @Resource
+    private Environment environment;
+
+    public Environment getEnvironment() {
+        return this.environment;
+    }
 
     /**
      * Annotated method that handles a given exception.

--- a/model/src/main/java/com/ge/predix/acs/rest/BaseResource.java
+++ b/model/src/main/java/com/ge/predix/acs/rest/BaseResource.java
@@ -15,18 +15,16 @@
  *******************************************************************************/
 package com.ge.predix.acs.rest;
 
-import java.util.Collections;
-import java.util.Set;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.ge.predix.acs.model.Attribute;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.ge.predix.acs.model.Attribute;
-
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Represents a Resource in the system identified by a subjectIdentifier.
@@ -54,7 +52,7 @@ public class BaseResource {
         this.resourceIdentifier = resourceIdentifier;
         this.attributes = attributes;
     }
-    
+
     public Set<Attribute> getAttributes() {
         return this.attributes;
     }

--- a/model/src/main/java/com/ge/predix/acs/rest/BaseSubject.java
+++ b/model/src/main/java/com/ge/predix/acs/rest/BaseSubject.java
@@ -15,18 +15,16 @@
  *******************************************************************************/
 package com.ge.predix.acs.rest;
 
-import java.util.Collections;
-import java.util.Set;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.ge.predix.acs.model.Attribute;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.ge.predix.acs.model.Attribute;
-
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Represents a Subject in the system identified by a subjectIdentifier.
@@ -104,5 +102,4 @@ public class BaseSubject {
     public String toString() {
         return "Subject [subjectIdentifier=" + this.subjectIdentifier + ", attributes=" + attributes + "]";
     }
-
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -425,6 +425,9 @@
                         <ZAC_CLIENT_ID>fake-client</ZAC_CLIENT_ID>
                         <ZAC_CLIENT_SECRET>fake-client</ZAC_CLIENT_SECRET>
                     </systemProperties>
+                    <excludes>
+                        <exclude>**/NonHierarchical*IT.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>
@@ -576,6 +579,7 @@
                             <excludes>
                                 <!-- Exclude graph database specific test for postgres profile -->
                                 <exclude>**/PolicyEvalWithGraphDbControllerIT.java</exclude>
+                                <exclude>**/Hierarchical*IT.java</exclude>
                             </excludes>
                         </configuration>
                         <executions>

--- a/service/src/main/java/com/ge/predix/acs/privilege/management/PrivilegeManagementServiceImpl.java
+++ b/service/src/main/java/com/ge/predix/acs/privilege/management/PrivilegeManagementServiceImpl.java
@@ -16,17 +16,6 @@
 
 package com.ge.predix.acs.privilege.management;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.ge.predix.acs.model.Attribute;
 import com.ge.predix.acs.policy.evaluation.cache.PolicyEvaluationCacheCircuitBreaker;
 import com.ge.predix.acs.privilege.management.dao.ResourceEntity;
@@ -37,6 +26,16 @@ import com.ge.predix.acs.rest.BaseResource;
 import com.ge.predix.acs.rest.BaseSubject;
 import com.ge.predix.acs.zone.management.dao.ZoneEntity;
 import com.ge.predix.acs.zone.resolver.ZoneResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * The implementation of privilege management.
@@ -421,6 +420,7 @@ public class PrivilegeManagementServiceImpl implements PrivilegeManagementServic
         if (r == null) {
             throw new PrivilegeManagementException("Resource is null.");
         }
+
         if (!r.isIdentifierValid()) {
             throw new PrivilegeManagementException(
                     String.format("Resource missing resourceIdentifier = %s ,this is mandatory for POST API",

--- a/service/src/test/java/com/ge/predix/acs/privilege/management/PrivilegeManagementServiceImplTest.java
+++ b/service/src/test/java/com/ge/predix/acs/privilege/management/PrivilegeManagementServiceImplTest.java
@@ -15,25 +15,6 @@
  *******************************************************************************/
 package com.ge.predix.acs.privilege.management;
 
-import static java.util.Arrays.asList;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTransactionalTestNGSpringContextTests;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
 import com.ge.predix.acs.SpringSecurityPolicyContextResolver;
 import com.ge.predix.acs.config.GraphBeanDefinitionRegistryPostProcessor;
 import com.ge.predix.acs.config.GraphConfig;
@@ -54,6 +35,24 @@ import com.ge.predix.acs.testutils.TestUtils;
 import com.ge.predix.acs.zone.management.ZoneService;
 import com.ge.predix.acs.zone.management.ZoneServiceImpl;
 import com.ge.predix.acs.zone.resolver.SpringSecurityZoneResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTransactionalTestNGSpringContextTests;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
 
 @ContextConfiguration(
         classes = { AcsRequestContextHolder.class, HystrixPolicyEvaluationCacheCircuitBreaker.class,

--- a/service/src/test/java/com/ge/predix/acs/testutils/XFiles.java
+++ b/service/src/test/java/com/ge/predix/acs/testutils/XFiles.java
@@ -1,14 +1,14 @@
 package com.ge.predix.acs.testutils;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.ge.predix.acs.model.Attribute;
 import com.ge.predix.acs.rest.BaseResource;
 import com.ge.predix.acs.rest.BaseSubject;
 import com.ge.predix.acs.rest.Parent;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public final class XFiles {
     private XFiles() {

--- a/service/src/test/java/com/ge/predix/controller/test/HierarchicalResourcesIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/HierarchicalResourcesIT.java
@@ -1,0 +1,152 @@
+package com.ge.predix.controller.test;
+
+import com.ge.predix.acs.rest.BaseResource;
+import com.ge.predix.acs.rest.Zone;
+import com.ge.predix.acs.testutils.MockAcsRequestContext;
+import com.ge.predix.acs.testutils.MockMvcContext;
+import com.ge.predix.acs.testutils.MockSecurityContext;
+import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
+import com.ge.predix.acs.zone.management.ZoneService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.ge.predix.acs.testutils.XFiles.ASCENSION_ID;
+import static com.ge.predix.acs.testutils.XFiles.BASEMENT_SITE_ID;
+import static com.ge.predix.acs.testutils.XFiles.EVIDENCE_SCULLYS_TESTIMONY_ID;
+import static com.ge.predix.acs.testutils.XFiles.SITE_BASEMENT;
+import static com.ge.predix.acs.testutils.XFiles.SPECIAL_AGENTS_GROUP_ATTRIBUTE;
+import static com.ge.predix.acs.testutils.XFiles.TOP_SECRET_CLASSIFICATION;
+import static com.ge.predix.acs.testutils.XFiles.TYPE_MYTHARC;
+import static com.ge.predix.acs.testutils.XFiles.createThreeLevelResourceHierarchy;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebAppConfiguration
+@ContextConfiguration("classpath:controller-tests-context.xml")
+@ActiveProfiles(resolver = TestActiveProfilesResolver.class)
+public class HierarchicalResourcesIT extends AbstractTestNGSpringContextTests {
+    private static Zone TEST_ZONE;
+
+    @Autowired
+    private ZoneService zoneService;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private ConfigurableEnvironment configurableEnvironment;
+
+    @BeforeClass
+    public void beforeClass() throws Exception {
+        if (!Arrays.asList(this.configurableEnvironment.getActiveProfiles()).contains("titan")) {
+            throw new SkipException("This test only applies when using the \"titan\" profile");
+        }
+
+        TEST_ZONE =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createTestZone("ResourceMgmtControllerIT");
+        this.zoneService.upsertZone(TEST_ZONE);
+        MockSecurityContext.mockSecurityContext(TEST_ZONE);
+        MockAcsRequestContext.mockAcsRequestContext(TEST_ZONE);
+    }
+
+    @Test
+    public void testPostAndGetHierarchicalResources() throws Exception {
+        List<BaseResource> resources = createThreeLevelResourceHierarchy();
+
+        // Append a list of resources
+        MockMvcContext postContext =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomPOSTRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                ResourcePrivilegeManagementControllerIT.RESOURCE_BASE_URL);
+
+        postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
+                                                    .content(ResourcePrivilegeManagementControllerIT.OBJECT_MAPPER
+                                                                 .writeValueAsString(resources)))
+                   .andExpect(status().isNoContent());
+
+        // Get the child resource without query string specifier.
+        MockMvcContext getContext0 =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomGETRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                ResourcePrivilegeManagementControllerIT.RESOURCE_BASE_URL + "/"
+                + URLEncoder.encode(EVIDENCE_SCULLYS_TESTIMONY_ID, "UTF-8"));
+
+        getContext0.getMockMvc().perform(getContext0.getBuilder()).andExpect(status().isOk())
+                   .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
+                   .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
+                   .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
+                   .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
+                   .andExpect(jsonPath("attributes[1]").doesNotExist());
+
+        // Get the child resource without inherited attributes.
+        MockMvcContext getContext1 =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomGETRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                ResourcePrivilegeManagementControllerIT.RESOURCE_BASE_URL + "/"
+                + URLEncoder.encode(EVIDENCE_SCULLYS_TESTIMONY_ID, "UTF-8") + "?includeInheritedAttributes=false");
+
+        getContext1.getMockMvc().perform(getContext1.getBuilder()).andExpect(status().isOk())
+                   .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
+                   .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
+                   .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
+                   .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
+                   .andExpect(jsonPath("attributes[1]").doesNotExist());
+
+        // Get the child resource with inherited attributes.
+        MockMvcContext getContext2 =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomGETRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                ResourcePrivilegeManagementControllerIT.RESOURCE_BASE_URL + "/"
+                + URLEncoder.encode(EVIDENCE_SCULLYS_TESTIMONY_ID, "UTF-8") + "?includeInheritedAttributes=true");
+
+        getContext2.getMockMvc().perform(getContext2.getBuilder()).andExpect(status().isOk())
+                       .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
+                       .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
+                       .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
+                       .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
+                       .andExpect(jsonPath("attributes[1].name", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getName())))
+                       .andExpect(jsonPath("attributes[1].value", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getValue())))
+                       .andExpect(jsonPath("attributes[1].issuer", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getIssuer())))
+                       .andExpect(jsonPath("attributes[2].name", is(TYPE_MYTHARC.getName())))
+                       .andExpect(jsonPath("attributes[2].value", is(TYPE_MYTHARC.getValue())))
+                       .andExpect(jsonPath("attributes[2].issuer", is(TYPE_MYTHARC.getIssuer())))
+                       .andExpect(jsonPath("attributes[3].name", is(SITE_BASEMENT.getName())))
+                       .andExpect(jsonPath("attributes[3].value", is(SITE_BASEMENT.getValue())))
+                       .andExpect(jsonPath("attributes[3].issuer", is(SITE_BASEMENT.getIssuer())));
+
+        // Clean up after ourselves.
+        deleteResource(EVIDENCE_SCULLYS_TESTIMONY_ID);
+        deleteResource(ASCENSION_ID);
+        deleteResource(BASEMENT_SITE_ID);
+    }
+
+    private void deleteResource(String resourceIdentifier) throws Exception {
+        String resourceToDeleteURI = ResourcePrivilegeManagementControllerIT.RESOURCE_BASE_URL + "/"
+                                     + URLEncoder.encode(resourceIdentifier, "UTF-8");
+
+        MockMvcContext deleteContext =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomDELETERequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(), resourceToDeleteURI);
+
+        deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
+    }
+}

--- a/service/src/test/java/com/ge/predix/controller/test/HierarchicalSubjectsIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/HierarchicalSubjectsIT.java
@@ -1,0 +1,154 @@
+package com.ge.predix.controller.test;
+
+import com.ge.predix.acs.rest.BaseSubject;
+import com.ge.predix.acs.rest.Zone;
+import com.ge.predix.acs.testutils.MockAcsRequestContext;
+import com.ge.predix.acs.testutils.MockMvcContext;
+import com.ge.predix.acs.testutils.MockSecurityContext;
+import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
+import com.ge.predix.acs.zone.management.ZoneService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.ge.predix.acs.testutils.XFiles.AGENT_MULDER;
+import static com.ge.predix.acs.testutils.XFiles.FBI;
+import static com.ge.predix.acs.testutils.XFiles.SITE_BASEMENT;
+import static com.ge.predix.acs.testutils.XFiles.SITE_QUANTICO;
+import static com.ge.predix.acs.testutils.XFiles.SPECIAL_AGENTS_GROUP;
+import static com.ge.predix.acs.testutils.XFiles.SPECIAL_AGENTS_GROUP_ATTRIBUTE;
+import static com.ge.predix.acs.testutils.XFiles.TOP_SECRET_CLASSIFICATION;
+import static com.ge.predix.acs.testutils.XFiles.TOP_SECRET_GROUP;
+import static com.ge.predix.acs.testutils.XFiles.createSubjectHierarchy;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebAppConfiguration
+@ContextConfiguration("classpath:controller-tests-context.xml")
+@ActiveProfiles(resolver = TestActiveProfilesResolver.class)
+public class HierarchicalSubjectsIT extends AbstractTestNGSpringContextTests {
+    private static Zone TEST_ZONE;
+
+    @Autowired
+    private ZoneService zoneService;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private ConfigurableEnvironment configurableEnvironment;
+
+    @BeforeClass
+    public void beforeClass() throws Exception {
+        if (!Arrays.asList(this.configurableEnvironment.getActiveProfiles()).contains("titan")) {
+            throw new SkipException("This test only applies when using the \"titan\" profile");
+        }
+
+        TEST_ZONE =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createTestZone("SubjectMgmtControllerIT");
+        this.zoneService.upsertZone(TEST_ZONE);
+        MockSecurityContext.mockSecurityContext(TEST_ZONE);
+        MockAcsRequestContext.mockAcsRequestContext(TEST_ZONE);
+    }
+
+    @Test
+    public void testPostAndGetHierarchicalSubjects() throws Exception {
+        List<BaseSubject> subjects = createSubjectHierarchy();
+
+        // Append a list of resources
+        MockMvcContext postContext =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomPOSTRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                SubjectPrivilegeManagementControllerIT.SUBJECT_BASE_URL);
+
+        postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
+                                                    .content(SubjectPrivilegeManagementControllerIT.OBJECT_MAPPER
+                                                                 .writeValueAsString(subjects)))
+                   .andExpect(status().isNoContent());
+
+        // Get the child subject without query string specifier.
+        MockMvcContext getContext0 =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomGETRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                SubjectPrivilegeManagementControllerIT.SUBJECT_BASE_URL + "/"
+                + URLEncoder.encode(AGENT_MULDER, "UTF-8"));
+
+        getContext0.getMockMvc().perform(getContext0.getBuilder()).andExpect(status().isOk())
+                   .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
+                   .andExpect(jsonPath("attributes[0].name", is(SITE_BASEMENT.getName())))
+                   .andExpect(jsonPath("attributes[0].value", is(SITE_BASEMENT.getValue())))
+                   .andExpect(jsonPath("attributes[0].issuer", is(SITE_BASEMENT.getIssuer())))
+                   .andExpect(jsonPath("attributes[1]").doesNotExist());
+
+        // Get the child subject without inherited attributes.
+        MockMvcContext getContext1 =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomGETRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                SubjectPrivilegeManagementControllerIT.SUBJECT_BASE_URL + "/"
+                + URLEncoder.encode(AGENT_MULDER, "UTF-8") + "?includeInheritedAttributes=false");
+
+        getContext1.getMockMvc().perform(getContext1.getBuilder()).andExpect(status().isOk())
+                   .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
+                   .andExpect(jsonPath("attributes[0].name", is(SITE_BASEMENT.getName())))
+                   .andExpect(jsonPath("attributes[0].value", is(SITE_BASEMENT.getValue())))
+                   .andExpect(jsonPath("attributes[0].issuer", is(SITE_BASEMENT.getIssuer())))
+                   .andExpect(jsonPath("attributes[1]").doesNotExist());
+
+        // Get the child subject with inherited attributes.
+        MockMvcContext getContext2 =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomGETRequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(),
+                SubjectPrivilegeManagementControllerIT.SUBJECT_BASE_URL + "/"
+                + URLEncoder.encode(AGENT_MULDER, "UTF-8") + "?includeInheritedAttributes=true");
+
+        getContext2.getMockMvc().perform(getContext2.getBuilder()).andExpect(status().isOk())
+                   .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
+                   .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
+                   .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
+                   .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
+                   .andExpect(jsonPath("attributes[1].name", is(SITE_QUANTICO.getName())))
+                   .andExpect(jsonPath("attributes[1].value", is(SITE_QUANTICO.getValue())))
+                   .andExpect(jsonPath("attributes[1].issuer", is(SITE_QUANTICO.getIssuer())))
+                   .andExpect(jsonPath("attributes[2].name", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getName())))
+                   .andExpect(jsonPath("attributes[2].value", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getValue())))
+                   .andExpect(jsonPath("attributes[2].issuer", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getIssuer())))
+                   .andExpect(jsonPath("attributes[3].name", is(SITE_BASEMENT.getName())))
+                   .andExpect(jsonPath("attributes[3].value", is(SITE_BASEMENT.getValue())))
+                   .andExpect(jsonPath("attributes[3].issuer", is(SITE_BASEMENT.getIssuer())));
+
+        // Clean up after ourselves.
+        deleteSubject(AGENT_MULDER);
+        deleteSubject(TOP_SECRET_GROUP);
+        deleteSubject(SPECIAL_AGENTS_GROUP);
+        deleteSubject(FBI);
+    }
+
+    private void deleteSubject(final String subjectIdentifier) throws Exception {
+        String subjectToDeleteURI = SubjectPrivilegeManagementControllerIT.SUBJECT_BASE_URL + "/"
+                                    + URLEncoder.encode(subjectIdentifier, "UTF-8");
+
+        MockMvcContext deleteContext =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomDELETERequestBuilder(
+                this.wac,
+                TEST_ZONE.getSubdomain(), subjectToDeleteURI);
+
+        deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
+    }
+}

--- a/service/src/test/java/com/ge/predix/controller/test/NonHierarchicalResourcesIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/NonHierarchicalResourcesIT.java
@@ -1,0 +1,79 @@
+package com.ge.predix.controller.test;
+
+import com.ge.predix.acs.commons.web.BaseRestApi;
+import com.ge.predix.acs.rest.BaseResource;
+import com.ge.predix.acs.rest.Zone;
+import com.ge.predix.acs.testutils.MockAcsRequestContext;
+import com.ge.predix.acs.testutils.MockMvcContext;
+import com.ge.predix.acs.testutils.MockSecurityContext;
+import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
+import com.ge.predix.acs.zone.management.ZoneService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebAppConfiguration
+@ContextConfiguration("classpath:controller-tests-context.xml")
+@ActiveProfiles(resolver = TestActiveProfilesResolver.class)
+public final class NonHierarchicalResourcesIT extends AbstractTestNGSpringContextTests {
+    private static Zone TEST_ZONE;
+
+    @Autowired
+    private ZoneService zoneService;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private ConfigurableEnvironment configurableEnvironment;
+
+    @BeforeClass
+    public void beforeClass() throws Exception {
+        if (Arrays.asList(this.configurableEnvironment.getActiveProfiles()).contains("titan")) {
+            throw new SkipException("This test only applies when NOT using the \"titan\" profile");
+        }
+
+        TEST_ZONE =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createTestZone("ResourceMgmtControllerIT");
+        this.zoneService.upsertZone(TEST_ZONE);
+        MockSecurityContext.mockSecurityContext(TEST_ZONE);
+        MockAcsRequestContext.mockAcsRequestContext(TEST_ZONE);
+    }
+
+    @Test
+    public void testResourceWithParentsFailWhenNotUsingTitan() throws Exception {
+        BaseResource resource = ResourcePrivilegeManagementControllerIT.JSON_UTILS.deserializeFromFile(
+            "controller-test/a-resource-with-parents.json", BaseResource.class);
+        Assert.assertNotNull(resource);
+
+        MockMvcContext putContext =
+            ResourcePrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomPUTRequestBuilder(
+                this.wac, TEST_ZONE.getSubdomain(),
+                ResourcePrivilegeManagementControllerIT.RESOURCE_BASE_URL
+                + "/%2Fservices%2Fsecured-api-with-parents");
+        final MvcResult result = putContext.getMockMvc()
+                                           .perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
+                                                              .content(ResourcePrivilegeManagementControllerIT
+                                                                           .OBJECT_MAPPER.writeValueAsString(resource)))
+                                           .andExpect(status().isNotImplemented())
+                                           .andReturn();
+
+        Assert.assertEquals(result.getResponse().getContentAsString(),
+                            "{\"ErrorDetails\":{\"errorCode\":\"FAILURE\","
+                            + "\"errorMessage\":\"" + BaseRestApi.PARENTS_ATTR_NOT_SUPPORTED_MSG + "\"}}");
+    }
+}

--- a/service/src/test/java/com/ge/predix/controller/test/NonHierarchicalSubjectsIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/NonHierarchicalSubjectsIT.java
@@ -1,0 +1,78 @@
+package com.ge.predix.controller.test;
+
+import com.ge.predix.acs.commons.web.BaseRestApi;
+import com.ge.predix.acs.rest.BaseSubject;
+import com.ge.predix.acs.rest.Zone;
+import com.ge.predix.acs.testutils.MockAcsRequestContext;
+import com.ge.predix.acs.testutils.MockMvcContext;
+import com.ge.predix.acs.testutils.MockSecurityContext;
+import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
+import com.ge.predix.acs.zone.management.ZoneService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebAppConfiguration
+@ContextConfiguration("classpath:controller-tests-context.xml")
+@ActiveProfiles(resolver = TestActiveProfilesResolver.class)
+public final class NonHierarchicalSubjectsIT extends AbstractTestNGSpringContextTests {
+    private static Zone TEST_ZONE;
+
+    @Autowired
+    private ZoneService zoneService;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private ConfigurableEnvironment configurableEnvironment;
+
+    @BeforeClass
+    public void beforeClass() throws Exception {
+        if (Arrays.asList(this.configurableEnvironment.getActiveProfiles()).contains("titan")) {
+            throw new SkipException("This test only applies when NOT using the \"titan\" profile");
+        }
+
+        TEST_ZONE =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createTestZone("SubjectMgmtControllerIT");
+        this.zoneService.upsertZone(TEST_ZONE);
+        MockSecurityContext.mockSecurityContext(TEST_ZONE);
+        MockAcsRequestContext.mockAcsRequestContext(TEST_ZONE);
+    }
+
+    @Test
+    public void testSubjectWithParentsFailWhenNotUsingTitan() throws Exception {
+        BaseSubject subject = SubjectPrivilegeManagementControllerIT.JSON_UTILS.deserializeFromFile(
+            "controller-test/a-subject-with-parents.json", BaseSubject.class);
+        Assert.assertNotNull(subject);
+
+        MockMvcContext putContext =
+            SubjectPrivilegeManagementControllerIT.TEST_UTILS.createWACWithCustomPUTRequestBuilder(
+                this.wac, TEST_ZONE.getSubdomain(),
+                SubjectPrivilegeManagementControllerIT.SUBJECT_BASE_URL + "/dave-with-parents");
+        final MvcResult result = putContext.getMockMvc()
+                                           .perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
+                                                              .content(ResourcePrivilegeManagementControllerIT
+                                                                           .OBJECT_MAPPER.writeValueAsString(subject)))
+                                           .andExpect(status().isNotImplemented())
+                                           .andReturn();
+
+        Assert.assertEquals(result.getResponse().getContentAsString(),
+                            "{\"ErrorDetails\":{\"errorCode\":\"FAILURE\","
+                            + "\"errorMessage\":\"" + BaseRestApi.PARENTS_ATTR_NOT_SUPPORTED_MSG + "\"}}");
+    }
+}

--- a/service/src/test/java/com/ge/predix/controller/test/ResourcePrivilegeManagementControllerIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/ResourcePrivilegeManagementControllerIT.java
@@ -16,23 +16,16 @@
 // @formatter:off
 package com.ge.predix.controller.test;
 
-import static com.ge.predix.acs.testutils.XFiles.ASCENSION_ID;
-import static com.ge.predix.acs.testutils.XFiles.BASEMENT_SITE_ID;
-import static com.ge.predix.acs.testutils.XFiles.EVIDENCE_SCULLYS_TESTIMONY_ID;
-import static com.ge.predix.acs.testutils.XFiles.SITE_BASEMENT;
-import static com.ge.predix.acs.testutils.XFiles.SPECIAL_AGENTS_GROUP_ATTRIBUTE;
-import static com.ge.predix.acs.testutils.XFiles.TOP_SECRET_CLASSIFICATION;
-import static com.ge.predix.acs.testutils.XFiles.TYPE_MYTHARC;
-import static com.ge.predix.acs.testutils.XFiles.createThreeLevelResourceHierarchy;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.List;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ge.predix.acs.rest.BaseResource;
+import com.ge.predix.acs.rest.Zone;
+import com.ge.predix.acs.testutils.MockAcsRequestContext;
+import com.ge.predix.acs.testutils.MockMvcContext;
+import com.ge.predix.acs.testutils.MockSecurityContext;
+import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
+import com.ge.predix.acs.testutils.TestUtils;
+import com.ge.predix.acs.utils.JsonUtils;
+import com.ge.predix.acs.zone.management.ZoneService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.MediaType;
@@ -45,27 +38,22 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ge.predix.acs.rest.BaseResource;
-import com.ge.predix.acs.rest.Zone;
-import com.ge.predix.acs.testutils.MockAcsRequestContext;
-import com.ge.predix.acs.testutils.MockMvcContext;
-import com.ge.predix.acs.testutils.MockSecurityContext;
-import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
-import com.ge.predix.acs.testutils.TestUtils;
-import com.ge.predix.acs.utils.JsonUtils;
-import com.ge.predix.acs.zone.management.ZoneService;
+import java.net.URLEncoder;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isIn;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebAppConfiguration
 @ContextConfiguration("classpath:controller-tests-context.xml")
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSpringContextTests {
-
-    public static final ConfigureEnvironment CONFIGURE_ENVIRONMENT = new ConfigureEnvironment();
-
-    private static final String RESOURCE_BASE_URL = "/v1/resource";
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static final String RESOURCE_BASE_URL = "/v1/resource";
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static final JsonUtils JSON_UTILS = new JsonUtils();
+    static final TestUtils TEST_UTILS = new TestUtils();
 
     @Autowired
     private WebApplicationContext wac;
@@ -73,21 +61,17 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
     @Autowired
     private ZoneService zoneService;
 
-    private final JsonUtils jsonUtils = new JsonUtils();
-
-    private final TestUtils testUtils = new TestUtils();
-
     private Zone testZone;
 
     private Zone testZone2;
 
     @Autowired
-    ConfigurableEnvironment env;
+    private ConfigurableEnvironment env;
 
     @BeforeClass
     public void setup() throws Exception {
-        this.testZone = new TestUtils().createTestZone("ResourceMgmtControllerIT");
-        this.testZone2 = new TestUtils().createTestZone("ResourceMgmtControllerIT2");
+        this.testZone = TEST_UTILS.createTestZone("ResourceMgmtControllerIT");
+        this.testZone2 = TEST_UTILS.createTestZone("ResourceMgmtControllerIT2");
         this.zoneService.upsertZone(this.testZone);
         this.zoneService.upsertZone(this.testZone2);
         MockSecurityContext.mockSecurityContext(this.testZone);
@@ -96,20 +80,20 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
 
     @Test
     public void testSameResourceDifferentZones() throws Exception {
-        BaseResource resource = this.jsonUtils.deserializeFromFile("controller-test/a-resource.json",
-                BaseResource.class);
+        BaseResource resource = JSON_UTILS.deserializeFromFile("controller-test/a-resource.json",
+                                                                    BaseResource.class);
         String thisUri = RESOURCE_BASE_URL + "/%2Fservices%2Fsecured-api";
         // create resource in first zone
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resource))).andExpect(status().isCreated());
 
         // create resource in second zone
         MockSecurityContext.mockSecurityContext(this.testZone2);
         MockAcsRequestContext.mockAcsRequestContext(this.testZone2);
-        putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone2.getSubdomain(),
-                thisUri);
+        putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone2.getSubdomain(),
+                                                                          thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resource))).andExpect(status().isCreated());
         // we expect both resources to be create in each zone
@@ -121,19 +105,19 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
     @SuppressWarnings("unchecked")
     public void testPOSTResources() throws Exception {
 
-        List<BaseResource> resources = this.jsonUtils.deserializeFromFile("controller-test/resources-collection.json",
-                List.class);
+        List<BaseResource> resources = JSON_UTILS.deserializeFromFile("controller-test/resources-collection.json",
+                                                                           List.class);
         Assert.assertNotNull(resources);
 
         // Append a list of resources
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), RESOURCE_BASE_URL);
         postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resources))).andExpect(status().isNoContent());
 
         // Get the list of resources
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), RESOURCE_BASE_URL);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(
                         jsonPath("$[0].resourceIdentifier",
@@ -148,138 +132,59 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
                 .andExpect(jsonPath("$[1].attributes[0].value", isIn(new String[] { "sales", "admin" })))
                 .andExpect(jsonPath("$[1].attributes[0].issuer", is("https://acs.attributes.int")));
 
-        BaseResource resource = this.jsonUtils.deserializeFromFile("controller-test/a-resource.json",
-                BaseResource.class);
+        BaseResource resource = JSON_UTILS.deserializeFromFile("controller-test/a-resource.json",
+                                                                    BaseResource.class);
         Assert.assertNotNull(resource);
 
         String aResourceURI = RESOURCE_BASE_URL + "/%2Fservices%2Fsecured-api";
 
         // Update a given resource
-        MockMvcContext updateContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), aResourceURI);
+        MockMvcContext updateContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                            this.testZone.getSubdomain(), aResourceURI);
         updateContext.getMockMvc().perform(updateContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resource))).andExpect(status().isNoContent());
 
         // Get a given resource
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                aResourceURI);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          aResourceURI);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(jsonPath("resourceIdentifier", is("/services/secured-api")))
                 .andExpect(jsonPath("attributes[0].value", isIn(new String[] { "supervisor", "it" })))
                 .andExpect(jsonPath("attributes[0].issuer", is("https://acs.attributes.int")));
 
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), aResourceURI);
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), aResourceURI);
 
         // Delete a given resource
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
         // Delete a given resource
-        deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac, this.testZone.getSubdomain(),
+        deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac, this.testZone.getSubdomain(),
                 RESOURCE_BASE_URL + "/01928374102398741235123");
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
         // Make sure resource does not exist anymore
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                "/tenant/ge/resource/0192837410239874");
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          "/tenant/ge/resource/0192837410239874");
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isNotFound());
 
         // Make sure resource does not exist anymore
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                "/tenant/ge/resource/01928374102398741235123");
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          "/tenant/ge/resource/01928374102398741235123");
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void testPostAndGetHierarchicalResources() throws Exception {
-
-        List<BaseResource> resources = createThreeLevelResourceHierarchy();
-
-        // Append a list of resources
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL);
-        postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
-                .content(OBJECT_MAPPER.writeValueAsString(resources))).andExpect(status().isNoContent());
-
-        // Get the child resource without query string specifier.
-        MockMvcContext getContext0 = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL + "/"
-                        + URLEncoder.encode(EVIDENCE_SCULLYS_TESTIMONY_ID, "UTF-8"));
-
-        getContext0.getMockMvc().perform(getContext0.getBuilder()).andExpect(status().isOk())
-            .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
-            .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
-            .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
-            .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
-            .andExpect(jsonPath("attributes[1]").doesNotExist());
-
-        // Get the child resource without inherited attributes.
-        MockMvcContext getContext1 = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL + "/"
-                        + URLEncoder.encode(EVIDENCE_SCULLYS_TESTIMONY_ID, "UTF-8")
-                        + "?includeInheritedAttributes=false");
-
-        getContext1.getMockMvc().perform(getContext1.getBuilder()).andExpect(status().isOk())
-            .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
-            .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
-            .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
-            .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
-            .andExpect(jsonPath("attributes[1]").doesNotExist());
-
-        // Get the child resource with inherited attributes.
-        MockMvcContext getContext2 = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL + "/"
-                        + URLEncoder.encode(EVIDENCE_SCULLYS_TESTIMONY_ID, "UTF-8")
-                        + "?includeInheritedAttributes=true");
-
-        if (!Arrays.asList(this.env.getActiveProfiles()).contains("titan")) {
-            getContext2.getMockMvc().perform(getContext2.getBuilder()).andExpect(status().isOk())
-                .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
-                .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
-                .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
-                .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
-                .andExpect(jsonPath("attributes[1]").doesNotExist());
-        } else {
-            getContext2.getMockMvc().perform(getContext2.getBuilder()).andExpect(status().isOk())
-                .andExpect(jsonPath("resourceIdentifier", is(EVIDENCE_SCULLYS_TESTIMONY_ID)))
-                .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
-                .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
-                .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
-                .andExpect(jsonPath("attributes[1].name", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getName())))
-                .andExpect(jsonPath("attributes[1].value", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getValue())))
-                .andExpect(jsonPath("attributes[1].issuer", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getIssuer())))
-                .andExpect(jsonPath("attributes[2].name", is(TYPE_MYTHARC.getName())))
-                .andExpect(jsonPath("attributes[2].value", is(TYPE_MYTHARC.getValue())))
-                .andExpect(jsonPath("attributes[2].issuer", is(TYPE_MYTHARC.getIssuer())))
-                .andExpect(jsonPath("attributes[3].name", is(SITE_BASEMENT.getName())))
-                .andExpect(jsonPath("attributes[3].value", is(SITE_BASEMENT.getValue())))
-                .andExpect(jsonPath("attributes[3].issuer", is(SITE_BASEMENT.getIssuer())));
-        }
-
-        // Clean up after ourselves.
-        deleteResource(EVIDENCE_SCULLYS_TESTIMONY_ID);
-        deleteResource(ASCENSION_ID);
-        deleteResource(BASEMENT_SITE_ID);
-    }
-
-    private void deleteResource(String resourceIdentifier) throws Exception {
-        String resourceToDeleteURI = RESOURCE_BASE_URL + "/" + URLEncoder.encode(resourceIdentifier, "UTF-8");
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), resourceToDeleteURI);
-        deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testPOSTResourcesMissingResourceId() throws Exception {
-        List<BaseResource> resources = this.jsonUtils.deserializeFromFile(
+        List<BaseResource> resources = JSON_UTILS.deserializeFromFile(
                 "controller-test/missing-resourceIdentifier-resources-collection.json", List.class);
 
         Assert.assertNotNull(resources);
 
         // Append a list of resources
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), RESOURCE_BASE_URL);
         postContext.getMockMvc()
                 .perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(resources)))
@@ -290,14 +195,14 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
     @Test
     @SuppressWarnings("unchecked")
     public void testPOSTResourcesMissingIdentifier() throws Exception {
-        List<BaseResource> resources = this.jsonUtils
+        List<BaseResource> resources = JSON_UTILS
                 .deserializeFromFile("controller-test/missing-identifier-resources-collection.json", List.class);
 
         Assert.assertNotNull(resources);
 
         // Append a list of resources
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), RESOURCE_BASE_URL);
         postContext.getMockMvc()
                 .perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(resources)))
@@ -308,14 +213,14 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
     @Test
     @SuppressWarnings("unchecked")
     public void testPOSTResourcesEmptyIdentifier() throws Exception {
-        List<BaseResource> resources = this.jsonUtils
+        List<BaseResource> resources = JSON_UTILS
                 .deserializeFromFile("controller-test/empty-identifier-resources-collection.json", List.class);
 
         Assert.assertNotNull(resources);
 
         // Append a list of resources
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), RESOURCE_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), RESOURCE_BASE_URL);
         postContext.getMockMvc()
                 .perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(resources)))
@@ -325,15 +230,15 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
     @Test
     public void testResourceIdentifierMismatch() throws Exception {
 
-        BaseResource resource = this.jsonUtils.deserializeFromFile("controller-test/a-mismatched-resourceid.json",
-                BaseResource.class);
+        BaseResource resource = JSON_UTILS.deserializeFromFile("controller-test/a-mismatched-resourceid.json",
+                                                                    BaseResource.class);
         Assert.assertNotNull(resource);
 
         String thisUri = RESOURCE_BASE_URL + "/%2Fservices%2Fsecured-api";
 
         // Update a given resource
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc()
                 .perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(resource)))
@@ -344,48 +249,48 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
     @Test
     public void testPUTResourceNoResourceId() throws Exception {
 
-        BaseResource resource = this.jsonUtils
+        BaseResource resource = JSON_UTILS
                 .deserializeFromFile("controller-test/no-resourceIdentifier-resource.json", BaseResource.class);
         Assert.assertNotNull(resource);
 
         String thisUri = RESOURCE_BASE_URL + "/%2Fservices%2Fsecured-api%2Fsubresource";
         // Update a given resource
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resource))).andExpect(status().is2xxSuccessful());
 
         // Get a given resource
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(jsonPath("resourceIdentifier", is("/services/secured-api/subresource")))
                 .andExpect(jsonPath("attributes[0].value", isIn(new String[] { "supervisor", "it" })))
                 .andExpect(jsonPath("attributes[0].issuer", is("https://acs.attributes.int")));
 
         // Delete a given resource
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), thisUri);
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
     }
 
     @Test
     public void testPUTCreateResourceThenUpdateNoResourceIdentifier() throws Exception {
 
-        BaseResource resource = this.jsonUtils
+        BaseResource resource = JSON_UTILS
                 .deserializeFromFile("controller-test/with-resourceIdentifier-resource.json", BaseResource.class);
         Assert.assertNotNull(resource);
 
         String thisUri = RESOURCE_BASE_URL + "/%2Fservices%2Fsecured-api%2Fsubresource";
 
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resource))).andExpect(status().isCreated());
 
         // Get a given resource
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(jsonPath("resourceIdentifier", is(resource.getResourceIdentifier())))
                 .andExpect(jsonPath("attributes[0].value", isIn(new String[] { "supervisor", "it" })))
@@ -394,29 +299,29 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
         // Ensure we can update resource without a resource identifier in json
         // payload
         // In this case, the resource identifier must be part of the URI.
-        BaseResource resourceNoResourceIdentifier = this.jsonUtils
+        BaseResource resourceNoResourceIdentifier = JSON_UTILS
                 .deserializeFromFile("controller-test/no-resourceIdentifier-resource.json", BaseResource.class);
         Assert.assertNotNull(resourceNoResourceIdentifier);
 
         // Update a given resource
-        putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         putContext.getMockMvc()
                 .perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(resourceNoResourceIdentifier)))
                 .andExpect(status().isNoContent());
 
         // Get a given resource
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(jsonPath("resourceIdentifier", is(resource.getResourceIdentifier())))
                 .andExpect(jsonPath("attributes[0].value", isIn(new String[] { "supervisor", "it" })))
                 .andExpect(jsonPath("attributes[0].issuer", is("https://acs.attributes.int")));
 
         // Delete a given resource
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), thisUri);
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
     }
@@ -431,17 +336,17 @@ public class ResourcePrivilegeManagementControllerIT extends AbstractTestNGSprin
         String encoded = URLEncoder.encode(decoded, "UTF-8");
         String thisUri = RESOURCE_BASE_URL + "/" + encoded;
 
-        BaseResource resource = this.jsonUtils
+        BaseResource resource = JSON_UTILS
                 .deserializeFromFile("controller-test/special-character-resource-identifier.json", BaseResource.class);
         Assert.assertNotNull(resource);
 
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(resource))).andExpect(status().isCreated());
 
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(jsonPath("resourceIdentifier", is(decoded)));
     }

--- a/service/src/test/java/com/ge/predix/controller/test/SubjectPrivilegeManagementControllerIT.java
+++ b/service/src/test/java/com/ge/predix/controller/test/SubjectPrivilegeManagementControllerIT.java
@@ -17,27 +17,16 @@
 
 package com.ge.predix.controller.test;
 
-import static com.ge.predix.acs.testutils.XFiles.AGENT_MULDER;
-import static com.ge.predix.acs.testutils.XFiles.FBI;
-import static com.ge.predix.acs.testutils.XFiles.SITE_BASEMENT;
-import static com.ge.predix.acs.testutils.XFiles.SITE_QUANTICO;
-import static com.ge.predix.acs.testutils.XFiles.SPECIAL_AGENTS_GROUP;
-import static com.ge.predix.acs.testutils.XFiles.SPECIAL_AGENTS_GROUP_ATTRIBUTE;
-import static com.ge.predix.acs.testutils.XFiles.TOP_SECRET_CLASSIFICATION;
-import static com.ge.predix.acs.testutils.XFiles.TOP_SECRET_GROUP;
-import static com.ge.predix.acs.testutils.XFiles.createSubjectHierarchy;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.security.auth.Subject;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ge.predix.acs.rest.BaseSubject;
+import com.ge.predix.acs.rest.Zone;
+import com.ge.predix.acs.testutils.MockAcsRequestContext;
+import com.ge.predix.acs.testutils.MockMvcContext;
+import com.ge.predix.acs.testutils.MockSecurityContext;
+import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
+import com.ge.predix.acs.testutils.TestUtils;
+import com.ge.predix.acs.utils.JsonUtils;
+import com.ge.predix.acs.zone.management.ZoneService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.MediaType;
@@ -51,16 +40,14 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ge.predix.acs.rest.BaseSubject;
-import com.ge.predix.acs.rest.Zone;
-import com.ge.predix.acs.testutils.MockAcsRequestContext;
-import com.ge.predix.acs.testutils.MockMvcContext;
-import com.ge.predix.acs.testutils.MockSecurityContext;
-import com.ge.predix.acs.testutils.TestActiveProfilesResolver;
-import com.ge.predix.acs.testutils.TestUtils;
-import com.ge.predix.acs.utils.JsonUtils;
-import com.ge.predix.acs.zone.management.ZoneService;
+import javax.security.auth.Subject;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isIn;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  *
@@ -70,10 +57,10 @@ import com.ge.predix.acs.zone.management.ZoneService;
 @ContextConfiguration("classpath:controller-tests-context.xml")
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpringContextTests {
-
-    public static final ConfigureEnvironment CONFIGURE_ENVIRONMENT = new ConfigureEnvironment();
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    static final String SUBJECT_BASE_URL = "/v1/subject";
+    static final JsonUtils JSON_UTILS = new JsonUtils();
+    static final TestUtils TEST_UTILS = new TestUtils();
 
     @Autowired
     private ZoneService zoneService;
@@ -81,21 +68,16 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @Autowired
     private WebApplicationContext wac;
 
-    private final JsonUtils jsonUtil = new JsonUtils();
-    private final TestUtils testUtils = new TestUtils();
-
     private Zone testZone;
     private Zone testZone2;
 
-    private static final String SUBJECT_BASE_URL = "/v1/subject";
-
     @Autowired
-    ConfigurableEnvironment env;
+    private ConfigurableEnvironment env;
 
     @BeforeClass
     public void setup() throws Exception {
-        this.testZone = new TestUtils().createTestZone("SubjectMgmtControllerIT");
-        this.testZone2 = new TestUtils().createTestZone("SubjectMgmtControllerIT2");
+        this.testZone = TEST_UTILS.createTestZone("SubjectMgmtControllerIT");
+        this.testZone2 = TEST_UTILS.createTestZone("SubjectMgmtControllerIT2");
         this.zoneService.upsertZone(this.testZone);
         this.zoneService.upsertZone(this.testZone2);
         MockSecurityContext.mockSecurityContext(this.testZone);
@@ -104,11 +86,11 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
 
     @Test
     public void testSameSubjectDifferentZones() throws Exception {
-        BaseSubject subject = this.jsonUtil.deserializeFromFile("controller-test/a-subject.json", BaseSubject.class);
+        BaseSubject subject = JSON_UTILS.deserializeFromFile("controller-test/a-subject.json", BaseSubject.class);
         String thisUri = SUBJECT_BASE_URL + "/dave";
         // create subject in first zone
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subject))).andExpect(status().isCreated());
 
@@ -116,8 +98,8 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
         MockSecurityContext.mockSecurityContext(this.testZone2);
         MockAcsRequestContext.mockAcsRequestContext(this.testZone2);
 
-        putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone2.getSubdomain(),
-                thisUri);
+        putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone2.getSubdomain(),
+                                                                          thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subject))).andExpect(status().isCreated());
         // we expect both subjects to be create in each zone
@@ -128,40 +110,40 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @Test
     @SuppressWarnings("unchecked")
     public void testSubjects() throws Exception {
-        List<Subject> subjects = this.jsonUtil.deserializeFromFile("controller-test/subjects-collection.json",
-                List.class);
+        List<Subject> subjects = JSON_UTILS.deserializeFromFile("controller-test/subjects-collection.json",
+                                                                     List.class);
         Assert.assertNotNull(subjects);
 
         // Append a list of subjects
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subjects))).andExpect(status().isNoContent());
 
         // Get the list of subjects
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), SUBJECT_BASE_URL);
 
         ResultActions resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
         assertSubjects(resultActions, 2, new String[] { "dave", "vineet" });
         assertSubjectsAttributes(resultActions, 2, 2, new String[] { "group", "department" },
                 new String[] { "sales", "admin" }, new String[] { "https://acs.attributes.int" });
 
-        BaseSubject subject = this.jsonUtil.deserializeFromFile("controller-test/a-subject.json", BaseSubject.class);
+        BaseSubject subject = JSON_UTILS.deserializeFromFile("controller-test/a-subject.json", BaseSubject.class);
         Assert.assertNotNull(subject);
 
         // Update a given subject
 
         String thisUri = SUBJECT_BASE_URL + "/dave";
 
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subject))).andExpect(status().isNoContent());
 
         // Get a given subject
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isOk())
                 .andExpect(jsonPath("subjectIdentifier", is("dave")))
                 .andExpect(jsonPath("attributes[0].value", isIn(new String[] { "supervisor", "it" })))
@@ -169,21 +151,21 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
 
         // Delete resources from created collection
         thisUri = SUBJECT_BASE_URL + "/vineet";
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), thisUri);
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
         // Make sure subject does not exist anymore
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isNotFound());
         thisUri = SUBJECT_BASE_URL + "/dave";
-        deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                                thisUri);
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
         // Make sure subject does not exist anymore
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         getContext.getMockMvc().perform(getContext.getBuilder()).andExpect(status().isNotFound());
     }
 
@@ -194,14 +176,14 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @SuppressWarnings("unchecked")
     public void testPOSTSubjectsMissingSubjectIdentifier() throws Exception {
 
-        List<Subject> subjects = this.jsonUtil
+        List<Subject> subjects = JSON_UTILS
                 .deserializeFromFile("controller-test/missing-subjectidentifier-collection.json", List.class);
 
         Assert.assertNotNull(subjects);
 
         // Append a list of subjects
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         postContext.getMockMvc()
                 .perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(subjects)))
@@ -212,13 +194,13 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @SuppressWarnings("unchecked")
     public void testPOSTSubjectsEmptyIdentifier() throws Exception {
 
-        List<Subject> subjects = this.jsonUtil
+        List<Subject> subjects = JSON_UTILS
                 .deserializeFromFile("controller-test/empty-identifier-subjects-collection.json", List.class);
         Assert.assertNotNull(subjects);
 
         // Append a list of subjects
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         postContext.getMockMvc()
                 .perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(subjects)))
@@ -228,14 +210,14 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
 
     @Test
     public void testPUTSubjectIdentifierMismatch() throws Exception {
-        BaseSubject subject = this.jsonUtil.deserializeFromFile("controller-test/a-mismatched-subjectidentifier.json",
-                BaseSubject.class);
+        BaseSubject subject = JSON_UTILS.deserializeFromFile("controller-test/a-mismatched-subjectidentifier.json",
+                                                                  BaseSubject.class);
         Assert.assertNotNull(subject);
 
         // Update a given resource
         String thisUri = SUBJECT_BASE_URL + "/dave";
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc()
                 .perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(subject)))
@@ -249,20 +231,20 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @Test
     public void testPUTSubjectNoSubjectIdentifier() throws Exception {
 
-        BaseSubject subject = this.jsonUtil.deserializeFromFile("controller-test/no-subjectidentifier-subject.json",
-                BaseSubject.class);
+        BaseSubject subject = JSON_UTILS.deserializeFromFile("controller-test/no-subjectidentifier-subject.json",
+                                                                  BaseSubject.class);
         Assert.assertNotNull(subject);
 
         // Update a given resource
         String thisUri = SUBJECT_BASE_URL + "/fermin";
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subject))).andExpect(status().is2xxSuccessful());
 
         // Get a given resource
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         ResultActions resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
 
         resultActions.andExpect(status().isOk()).andExpect(jsonPath("subjectIdentifier", is("fermin")))
@@ -270,8 +252,8 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
                 .andExpect(jsonPath("attributes[0].issuer", is("https://acs.attributes.int")));
 
         // Delete a given resource
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), thisUri);
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
         // Make sure subject does not exist anymore
@@ -281,39 +263,39 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @Test
     public void testPUTCreateSubjectThenUpdateNoSubjectIdentifier() throws Exception {
 
-        BaseSubject subject = this.jsonUtil.deserializeFromFile("controller-test/with-subjectidentifier-subject.json",
-                BaseSubject.class);
+        BaseSubject subject = JSON_UTILS.deserializeFromFile("controller-test/with-subjectidentifier-subject.json",
+                                                                  BaseSubject.class);
         Assert.assertNotNull(subject);
 
         String subjectIdentifier = "fermin";
         String thisUri = SUBJECT_BASE_URL + "/" + subjectIdentifier;
 
-        MockMvcContext putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         putContext.getMockMvc().perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subject))).andExpect(status().isCreated());
 
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), thisUri);
         ResultActions resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
 
         resultActions.andExpect(status().isOk()).andExpect(jsonPath("subjectIdentifier", is(subjectIdentifier)))
                 .andExpect(jsonPath("attributes[0].value", isIn(new String[] { "admin", "sales" })))
                 .andExpect(jsonPath("attributes[0].issuer", is("https://acs.attributes.int")));
 
-        BaseSubject subjectNoSubjectIdentifier = this.jsonUtil
+        BaseSubject subjectNoSubjectIdentifier = JSON_UTILS
                 .deserializeFromFile("controller-test/no-subjectidentifier-subject.json", BaseSubject.class);
         Assert.assertNotNull(subjectNoSubjectIdentifier);
 
-        putContext = this.testUtils.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        putContext = TEST_UTILS.createWACWithCustomPUTRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         putContext.getMockMvc()
                 .perform(putContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(subjectNoSubjectIdentifier)))
                 .andExpect(status().isNoContent());
 
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                thisUri);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          thisUri);
         resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
 
         resultActions.andExpect(status().isOk()).andExpect(jsonPath("subjectIdentifier", is(subjectIdentifier)))
@@ -321,8 +303,8 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
                 .andExpect(jsonPath("attributes[0].issuer", is("https://acs.attributes.int")));
 
         // Delete a given resource
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), thisUri);
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), thisUri);
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
     }
@@ -331,130 +313,50 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     @SuppressWarnings("unchecked")
     public void testPOSTCreateSubjectThenUpdateAttributes() throws Exception {
         // appending two subjects, the key one for this test is dave.
-        List<BaseSubject> subjects = this.jsonUtil.deserializeFromFile("controller-test/subjects-collection.json",
-                List.class);
+        List<BaseSubject> subjects = JSON_UTILS.deserializeFromFile("controller-test/subjects-collection.json",
+                                                                         List.class);
         Assert.assertNotNull(subjects);
 
         // Append a list of subjects
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subjects))).andExpect(status().isNoContent());
 
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         ResultActions resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
 
         assertSubjects(resultActions, 2, new String[] { "dave", "vineet" });
         assertSubjectsAttributes(resultActions, 2, 2, new String[] { "group", "department" },
                 new String[] { "admin", "sales" }, new String[] { "https://acs.attributes.int" });
 
-        subjects = this.jsonUtil
+        subjects = JSON_UTILS
                 .deserializeFromFile("controller-test/subjects-collection-with-different-attributes.json", List.class);
         Assert.assertNotNull(subjects);
 
-        postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                SUBJECT_BASE_URL);
+        postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                            SUBJECT_BASE_URL);
         postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subjects))).andExpect(status().isNoContent());
 
-        getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
-                SUBJECT_BASE_URL);
+        getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac, this.testZone.getSubdomain(),
+                                                                          SUBJECT_BASE_URL);
         resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
         assertSubjects(resultActions, 2, new String[] { "dave", "vineet" });
         assertSubjectsAttributes(resultActions, 2, 2, new String[] { "group", "department" },
                 new String[] { "different", "sales" }, new String[] { "https://acs.attributes.int" });
 
         // delete dave
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/dave");
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/dave");
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
         // delete vineet
-        deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac, this.testZone.getSubdomain(),
+        deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac, this.testZone.getSubdomain(),
                 SUBJECT_BASE_URL + "/vineet");
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
 
-    }
-
-    @Test
-    public void testPostAndGetHierarchicalSubjects() throws Exception {
-
-        List<BaseSubject> subjects = createSubjectHierarchy();
-
-        // Append a list of resources
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
-        postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
-                .content(OBJECT_MAPPER.writeValueAsString(subjects))).andExpect(status().isNoContent());
-
-        // Get the child subject without query string specifier.
-        MockMvcContext getContext0 = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/"
-                        + URLEncoder.encode(AGENT_MULDER, "UTF-8"));
-
-        getContext0.getMockMvc().perform(getContext0.getBuilder()).andExpect(status().isOk())
-            .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
-            .andExpect(jsonPath("attributes[0].name", is(SITE_BASEMENT.getName())))
-            .andExpect(jsonPath("attributes[0].value", is(SITE_BASEMENT.getValue())))
-            .andExpect(jsonPath("attributes[0].issuer", is(SITE_BASEMENT.getIssuer())))
-            .andExpect(jsonPath("attributes[1]").doesNotExist());
-
-        // Get the child subject without inherited attributes.
-        MockMvcContext getContext1 = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/"
-                        + URLEncoder.encode(AGENT_MULDER, "UTF-8")
-                        + "?includeInheritedAttributes=false");
-
-        getContext1.getMockMvc().perform(getContext1.getBuilder()).andExpect(status().isOk())
-            .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
-            .andExpect(jsonPath("attributes[0].name", is(SITE_BASEMENT.getName())))
-            .andExpect(jsonPath("attributes[0].value", is(SITE_BASEMENT.getValue())))
-            .andExpect(jsonPath("attributes[0].issuer", is(SITE_BASEMENT.getIssuer())))
-            .andExpect(jsonPath("attributes[1]").doesNotExist());
-
-        // Get the child subject with inherited attributes.
-        MockMvcContext getContext2 = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/"
-                        + URLEncoder.encode(AGENT_MULDER, "UTF-8")
-                        + "?includeInheritedAttributes=true");
-
-        if (!Arrays.asList(this.env.getActiveProfiles()).contains("titan")) {
-            getContext2.getMockMvc().perform(getContext2.getBuilder()).andExpect(status().isOk())
-                .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
-                .andExpect(jsonPath("attributes[0].name", is(SITE_BASEMENT.getName())))
-                .andExpect(jsonPath("attributes[0].value", is(SITE_BASEMENT.getValue())))
-                .andExpect(jsonPath("attributes[0].issuer", is(SITE_BASEMENT.getIssuer())))
-                .andExpect(jsonPath("attributes[1]").doesNotExist());
-        } else {
-            getContext2.getMockMvc().perform(getContext2.getBuilder()).andExpect(status().isOk())
-                .andExpect(jsonPath("subjectIdentifier", is(AGENT_MULDER)))
-                .andExpect(jsonPath("attributes[0].name", is(TOP_SECRET_CLASSIFICATION.getName())))
-                .andExpect(jsonPath("attributes[0].value", is(TOP_SECRET_CLASSIFICATION.getValue())))
-                .andExpect(jsonPath("attributes[0].issuer", is(TOP_SECRET_CLASSIFICATION.getIssuer())))
-                .andExpect(jsonPath("attributes[1].name", is(SITE_QUANTICO.getName())))
-                .andExpect(jsonPath("attributes[1].value", is(SITE_QUANTICO.getValue())))
-                .andExpect(jsonPath("attributes[1].issuer", is(SITE_QUANTICO.getIssuer())))
-                .andExpect(jsonPath("attributes[2].name", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getName())))
-                .andExpect(jsonPath("attributes[2].value", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getValue())))
-                .andExpect(jsonPath("attributes[2].issuer", is(SPECIAL_AGENTS_GROUP_ATTRIBUTE.getIssuer())))
-                .andExpect(jsonPath("attributes[3].name", is(SITE_BASEMENT.getName())))
-                .andExpect(jsonPath("attributes[3].value", is(SITE_BASEMENT.getValue())))
-                .andExpect(jsonPath("attributes[3].issuer", is(SITE_BASEMENT.getIssuer())));
-        }
-
-        // Clean up after ourselves.
-        deleteSubject(AGENT_MULDER);
-        deleteSubject(TOP_SECRET_GROUP);
-        deleteSubject(SPECIAL_AGENTS_GROUP);
-        deleteSubject(FBI);
-    }
-
-    private void deleteSubject(final String subjectIdentifier) throws Exception {
-        String subjectToDeleteURI = SUBJECT_BASE_URL + "/" + URLEncoder.encode(subjectIdentifier, "UTF-8");
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), subjectToDeleteURI);
-        deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
     }
 
     @Test
@@ -462,23 +364,23 @@ public class SubjectPrivilegeManagementControllerIT extends AbstractTestNGSpring
     public void testPOSTCreateSubjectNoDuplicates() throws Exception {
         // appending two subjects, the key one for this test is dave.
 
-        List<BaseSubject> subjects = this.jsonUtil
+        List<BaseSubject> subjects = JSON_UTILS
                 .deserializeFromFile("controller-test/a-single-subject-collection.json", List.class);
         Assert.assertNotNull(subjects);
 
         // Append a list of subjects
-        MockMvcContext postContext = this.testUtils.createWACWithCustomPOSTRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext postContext = TEST_UTILS.createWACWithCustomPOSTRequestBuilder(this.wac,
+                                                                                           this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         postContext.getMockMvc().perform(postContext.getBuilder().contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(subjects))).andExpect(status().isNoContent());
 
-        MockMvcContext getContext = this.testUtils.createWACWithCustomGETRequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL);
+        MockMvcContext getContext = TEST_UTILS.createWACWithCustomGETRequestBuilder(this.wac,
+                                                                                         this.testZone.getSubdomain(), SUBJECT_BASE_URL);
         ResultActions resultActions = getContext.getMockMvc().perform(getContext.getBuilder());
         assertSubjects(resultActions, 1, new String[] { "dave" });
 
-        MockMvcContext deleteContext = this.testUtils.createWACWithCustomDELETERequestBuilder(this.wac,
-                this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/dave");
+        MockMvcContext deleteContext = TEST_UTILS.createWACWithCustomDELETERequestBuilder(this.wac,
+                                                                                               this.testZone.getSubdomain(), SUBJECT_BASE_URL + "/dave");
         deleteContext.getMockMvc().perform(deleteContext.getBuilder()).andExpect(status().isNoContent());
     }
 

--- a/service/src/test/resources/controller-test/a-resource-with-parents.json
+++ b/service/src/test/resources/controller-test/a-resource-with-parents.json
@@ -1,0 +1,26 @@
+{
+	"resourceIdentifier" : "/services/secured-api-with-parents",
+	"attributes" : [
+	    { "issuer" : "https://acs.attributes.int",
+	      "name" : "group",
+	      "value": "supervisor"
+	    }
+	    ,
+	    { "issuer" : "https://acs.attributes.int",
+	      "name" : "department",
+	       "value": "it"
+	    }
+	],
+	"parents" : [
+		{
+			"identifier" : "role-analyst",
+			"scopes" : [
+				{
+					"issuer" : "https://acs.predix.io",
+					"name"   : "site",
+					"value"  : "san-ramon"
+				}
+			]
+		}
+	]
+}

--- a/service/src/test/resources/controller-test/a-subject-with-parents.json
+++ b/service/src/test/resources/controller-test/a-subject-with-parents.json
@@ -1,0 +1,26 @@
+{
+	"subjectIdentifier" : "dave-with-parents",
+	"attributes" : [
+	    { "issuer" : "https://acs.attributes.int",
+	      "name" : "group",
+	      "value": "supervisor"
+	    }
+	    ,
+	    { "issuer" : "https://acs.attributes.int",
+	      "name" : "department",
+	       "value": "it"
+	    }
+	],
+	"parents" : [
+		{
+			"identifier" : "role-analyst",
+			"scopes" : [
+				{
+					"issuer" : "https://acs.predix.io",
+					"name"   : "site",
+					"value"  : "san-ramon"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
US47429: Added functionality to gracefully fail when upserting parents in the absence of a Titan profile

Signed-off-by: Frank <frank.gasparovic@ge.com>