### PR TITLE
DE22023: Enabled logging integration test boundaries (i.e. when they …

### DIFF
--- a/acs-integration-tests/pom.xml
+++ b/acs-integration-tests/pom.xml
@@ -93,6 +93,12 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>com.ge.predix.test.TestNameLogger</value>
+                        </property>
+                    </properties>
                     <systemPropertyVariables>
                         <ACS_SERVICE_ID>predix-acs</ACS_SERVICE_ID>
                         <ACS_DEFAULT_ISSUER_ID>${ACS_DEFAULT_ISSUER_ID}</ACS_DEFAULT_ISSUER_ID>
@@ -990,9 +996,6 @@
                             <includes>
                                 <include>**/ACSAcceptanceIT.java</include>
                             </includes>
-                            <excludes>
-                                <exclude>**/NonHierarchical*IT.java</exclude>
-                            </excludes>
                         </configuration>
                         <executions>
                             <execution>

--- a/acs-integration-tests/src/test/java/com/ge/predix/integration/test/ACSMeteringIT.java
+++ b/acs-integration-tests/src/test/java/com/ge/predix/integration/test/ACSMeteringIT.java
@@ -50,7 +50,7 @@ import com.nurego.model.Subscription;
 
 @SuppressWarnings({ "nls" })
 @ContextConfiguration("classpath:integration-test-spring-context.xml")
-@Test
+@Test(enabled = false)
 public class ACSMeteringIT extends AbstractTestNGSpringContextTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(ACSMeteringIT.class);
 

--- a/acs-integration-tests/src/test/java/com/ge/predix/test/TestNameLogger.java
+++ b/acs-integration-tests/src/test/java/com/ge/predix/test/TestNameLogger.java
@@ -1,0 +1,40 @@
+package com.ge.predix.test;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.IClass;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+public class TestNameLogger implements IInvokedMethodListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestNameLogger.class);
+
+    private static void logInvocation(final String prefix, final IInvokedMethod method) {
+        if (!method.isTestMethod()) {
+            return;
+        }
+
+        ITestNGMethod iTestNGMethod = method.getTestMethod();
+        IClass iClass = iTestNGMethod.getTestClass();
+        String methodName = iClass.getName() + '#' + iTestNGMethod.getMethodName();
+
+        if (StringUtils.isEmpty(methodName)) {
+            return;
+        }
+
+        LOGGER.info("=== {} test: {}", prefix, methodName);
+    }
+
+    @Override
+    public void beforeInvocation(final IInvokedMethod method, final ITestResult testResult) {
+        logInvocation("Starting", method);
+    }
+
+    @Override
+    public void afterInvocation(final IInvokedMethod method, final ITestResult testResult) {
+        logInvocation("Finished", method);
+    }
+}

--- a/acs-integration-tests/src/test/resources/log4j.xml
+++ b/acs-integration-tests/src/test/resources/log4j.xml
@@ -53,6 +53,9 @@
         <level value ="debug" />
     </logger>
 
+    <logger name="com.ge.predix.test.TestNameLogger">
+        <level value="DEBUG"/>
+    </logger>
 
     <root>
         <level value = "INFO" />


### PR DESCRIPTION
…start and finish) and disabled the ACSMeteringIT integration test for all non-open-source Maven profiles