### PR TITLE
Made the following changes:

### DIFF
--- a/acs-integration-tests/pom.xml
+++ b/acs-integration-tests/pom.xml
@@ -612,7 +612,7 @@
                             <argLine/>
                             <systemPropertyVariables>
                                 <ZAC_UAA_URL>${ZAC_UAA_URL}</ZAC_UAA_URL>
-                                <spring.profiles.active>h2,predix,simple-cache</spring.profiles.active>
+                                <spring.profiles.active>h2,predix,simple-cache,httpValidation</spring.profiles.active>
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/ACSPerformanceIT.java</exclude>
@@ -658,7 +658,52 @@
                             <groupId>commons-io</groupId>
                             <artifactId>commons-io</artifactId>
                         </exclusion>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-handler</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-codec-http</artifactId>
+                        </exclusion>
                     </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.ge.predix.eventhub</groupId>
+                    <artifactId>predix-event-hub-sdk</artifactId>
+                    <version>1.2.2-SNAPSHOT</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>grpc-stub</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>grpc-protobuf</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-handler</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>commons-io</groupId>
+                            <artifactId>commons-io</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-codec-http</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-stub</artifactId>
+                    <version>1.0.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-protobuf</artifactId>
+                    <version>1.0.1</version>
                 </dependency>
             </dependencies>
             <build>
@@ -672,7 +717,7 @@
                             <argLine/>
                             <systemPropertyVariables>
                                 <ZAC_UAA_URL>${ZAC_UAA_URL}</ZAC_UAA_URL>
-                                <spring.profiles.active>h2,predix,simple-cache,titan</spring.profiles.active>
+                                <spring.profiles.active>h2,predix,simple-cache,titan,httpValidation</spring.profiles.active>
                             </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/ACSPerformanceIT.java</exclude>
@@ -769,7 +814,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <environmentVariables>
-                                <SPRING_PROFILES_ACTIVE>h2,public,simple-cache</SPRING_PROFILES_ACTIVE>
+                                <SPRING_PROFILES_ACTIVE>h2,public,simple-cache,httpValidation</SPRING_PROFILES_ACTIVE>
                                 <management.health.redis.enabled>false</management.health.redis.enabled>
                                 <uaaCheckHealthUrl>${ACS_UAA_URL}/healthz</uaaCheckHealthUrl>
                                 <cors.xhr.allowed.headers>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method, Access-Control-Request-Headers</cors.xhr.allowed.headers>
@@ -878,7 +923,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <environmentVariables>
-                                <SPRING_PROFILES_ACTIVE>h2,public,simple-cache,titan</SPRING_PROFILES_ACTIVE>
+                                <SPRING_PROFILES_ACTIVE>h2,public,simple-cache,titan,httpValidation</SPRING_PROFILES_ACTIVE>
                                 <management.health.redis.enabled>false</management.health.redis.enabled>
                                 <uaaCheckHealthUrl>${ACS_UAA_URL}/healthz</uaaCheckHealthUrl>
                                 <cors.xhr.allowed.headers>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method, Access-Control-Request-Headers</cors.xhr.allowed.headers>

--- a/acs-integration-tests/src/test/java/com/ge/predix/acceptance/test/ACSAcceptanceIT.java
+++ b/acs-integration-tests/src/test/java/com/ge/predix/acceptance/test/ACSAcceptanceIT.java
@@ -19,15 +19,18 @@ package com.ge.predix.acceptance.test;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.test.context.ContextConfiguration;
@@ -39,6 +42,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.ge.predix.acs.commons.web.AcsApiUriTemplates;
 import com.ge.predix.acs.model.Attribute;
 import com.ge.predix.acs.model.Effect;
 import com.ge.predix.acs.rest.BaseResource;
@@ -61,6 +65,9 @@ public class ACSAcceptanceIT extends AbstractTestNGSpringContextTests {
 
     @Value("${ACS_URL}")
     private String acsBaseUrl;
+
+    @Autowired
+    private Environment environment;
 
     @Autowired
     private ZoneHelper zoneHelper;
@@ -107,8 +114,8 @@ public class ACSAcceptanceIT extends AbstractTestNGSpringContextTests {
 
         RestTemplate restTemplate = new RestTemplate();
         try {
-            ResponseEntity<String> heartbeatResponse = restTemplate
-                    .exchange(this.acsBaseUrl + "/monitoring/heartbeat", HttpMethod.GET,
+            ResponseEntity<String> heartbeatResponse =
+                    restTemplate.exchange(this.acsBaseUrl + AcsApiUriTemplates.HEARTBEAT_URL, HttpMethod.GET,
                             new HttpEntity<>(this.headersWithZoneSubdomain), String.class);
             Assert.assertEquals(heartbeatResponse.getBody(), "alive", "ACS Heartbeat Check Failed");
         } catch (Exception e) {
@@ -154,11 +161,11 @@ public class ACSAcceptanceIT extends AbstractTestNGSpringContextTests {
             BaseResource resource = new BaseResource();
             resource.setResourceIdentifier("/alarms/sites/sanramon");
 
-            testResource = this.privilegeHelper
-                    .putResource(this.acsZoneRestTemplate, resource, endpoint, headers, region);
+            testResource =
+                    this.privilegeHelper.putResource(this.acsZoneRestTemplate, resource, endpoint, headers, region);
 
-            ResponseEntity<PolicyEvaluationResult> evalResponse = this.acsZoneRestTemplate
-                    .postForEntity(endpoint + PolicyHelper.ACS_POLICY_EVAL_API_PATH,
+            ResponseEntity<PolicyEvaluationResult> evalResponse =
+                    this.acsZoneRestTemplate.postForEntity(endpoint + PolicyHelper.ACS_POLICY_EVAL_API_PATH,
                             new HttpEntity<>(policyEvalRequest, headers), PolicyEvaluationResult.class);
 
             Assert.assertEquals(evalResponse.getStatusCode(), HttpStatus.OK);
@@ -167,16 +174,15 @@ public class ACSAcceptanceIT extends AbstractTestNGSpringContextTests {
         } finally {
             // delete policy
             if (null != testPolicyName) {
-                this.acsZoneRestTemplate
-                        .exchange(endpoint + PolicyHelper.ACS_POLICY_SET_API_PATH + testPolicyName, HttpMethod.DELETE,
-                                new HttpEntity<>(headers), String.class);
+                this.acsZoneRestTemplate.exchange(endpoint + PolicyHelper.ACS_POLICY_SET_API_PATH + testPolicyName,
+                        HttpMethod.DELETE, new HttpEntity<>(headers), String.class);
             }
 
             // delete attributes
             if (null != marissa) {
-                this.acsZoneRestTemplate
-                        .exchange(endpoint + PrivilegeHelper.ACS_SUBJECT_API_PATH + marissa.getSubjectIdentifier(),
-                                HttpMethod.DELETE, new HttpEntity<>(headers), String.class);
+                this.acsZoneRestTemplate.exchange(
+                        endpoint + PrivilegeHelper.ACS_SUBJECT_API_PATH + marissa.getSubjectIdentifier(),
+                        HttpMethod.DELETE, new HttpEntity<>(headers), String.class);
             }
             if (null != testResource) {
                 String encodedResource = URLEncoder.encode(testResource.getResourceIdentifier(), "UTF-8");
@@ -188,10 +194,25 @@ public class ACSAcceptanceIT extends AbstractTestNGSpringContextTests {
 
     @DataProvider(name = "endpointProvider")
     public Object[][] getAcsEndpoint() throws Exception {
-        PolicyEvaluationRequestV1 policyEvalForBob = this.policyHelper
-                .createEvalRequest("GET", "bob", "/alarms/sites/sanramon", null);
+        PolicyEvaluationRequestV1 policyEvalForBob =
+                this.policyHelper.createEvalRequest("GET", "bob", "/alarms/sites/sanramon", null);
 
         return new Object[][] { { this.acsBaseUrl, this.headersWithZoneSubdomain, policyEvalForBob, "bob" } };
+    }
+
+    // TODO: Remove this test when the "httpValidation" Spring profile is removed
+    @Test
+    public void testHttpValidationBasedOnActiveSpringProfile() throws Exception {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        ResponseEntity<String> response =
+                new RestTemplate().exchange(URI.create(this.acsBaseUrl + AcsApiUriTemplates.HEARTBEAT_URL),
+                        HttpMethod.GET, new HttpEntity<>(headers), String.class);
+        Assert.assertEquals(response.getStatusCode(),
+                (Arrays.asList(this.environment.getActiveProfiles()).contains("httpValidation")
+                        ? HttpStatus.OK : HttpStatus.NOT_ACCEPTABLE));
     }
 
     @AfterClass

--- a/service/src/main/java/com/ge/predix/acs/security/AbstractHttpMethodsFilter.java
+++ b/service/src/main/java/com/ge/predix/acs/security/AbstractHttpMethodsFilter.java
@@ -14,6 +14,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.MimeType;
@@ -25,6 +27,8 @@ import com.google.common.net.HttpHeaders;
 public abstract class AbstractHttpMethodsFilter extends OncePerRequestFilter {
 
     private final Map<String, Set<HttpMethod>> uriPatternsAndAllowedHttpMethods;
+
+    private static final Logger LOGGER_INSTANCE = LoggerFactory.getLogger(AbstractHttpMethodsFilter.class);
     private static final Set<MimeType> ACCEPTABLE_MIME_TYPES =
             new HashSet<>(Arrays.asList(MimeTypeUtils.ALL, MimeTypeUtils.APPLICATION_JSON, MimeTypeUtils.TEXT_PLAIN));
 
@@ -85,6 +89,7 @@ public abstract class AbstractHttpMethodsFilter extends OncePerRequestFilter {
                                 }
                             }
                             if (!foundAcceptableMimeType) {
+                                LOGGER_INSTANCE.error("Malformed Accept header sent in request: {}", acceptHeaderValue);
                                 sendNotAcceptableError(response);
                                 return;
                             }

--- a/service/start-acs-postgres-predix-titan.sh
+++ b/service/start-acs-postgres-predix-titan.sh
@@ -23,7 +23,9 @@
 # 4. execute: 'create user postgres;'
 # 5. execute: 'grant all privileges on database acs to postgres;'
 
-export SPRING_PROFILES_ACTIVE='envDbConfig,predix,simple-cache,titan'
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='envDbConfig,predix,simple-cache,titan'
+fi
 export DB_DRIVER_CLASS_NAME='org.postgresql.Driver'
 export DB_URL='jdbc:postgresql:acs'
 export DB_USERNAME='postgres'

--- a/service/start-acs-postgres-predix.sh
+++ b/service/start-acs-postgres-predix.sh
@@ -23,7 +23,9 @@
 # 4. execute: 'create user postgres;'
 # 5. execute: 'grant all privileges on database acs to postgres;'
 
-export SPRING_PROFILES_ACTIVE='envDbConfig,predix,simple-cache'
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='envDbConfig,predix,simple-cache'
+fi
 export DB_DRIVER_CLASS_NAME='org.postgresql.Driver'
 export DB_URL='jdbc:postgresql:acs'
 export DB_USERNAME='postgres'

--- a/service/start-acs-postgres.sh
+++ b/service/start-acs-postgres.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 #*******************************************************************************
-# Copyright 2016 General Electric Company. 
+# Copyright 2016 General Electric Company.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 #*******************************************************************************
 
@@ -23,7 +23,9 @@
 # 4. execute: 'create user postgres;'
 # 5. execute: 'grant all privileges on database acs to postgres;'
 
-export SPRING_PROFILES_ACTIVE='envDbConfig,public,simple-cache'
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='envDbConfig,public,simple-cache'
+fi
 export DB_DRIVER_CLASS_NAME='org.postgresql.Driver'
 export DB_URL='jdbc:postgresql:acs'
 export DB_USERNAME='postgres'

--- a/service/start-acs-predix-titan.sh
+++ b/service/start-acs-predix-titan.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
 #*******************************************************************************
-# Copyright 2016 General Electric Company. 
+# Copyright 2016 General Electric Company.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 #*******************************************************************************
 
-export SPRING_PROFILES_ACTIVE='h2,predix,simple-cache,titan'
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='h2,predix,simple-cache,titan'
+fi
 export DIR=$( dirname "$( python -c "import os; print os.path.abspath('${BASH_SOURCE[0]}')" )" )
 source "${DIR}/start-acs.sh" "$@"

--- a/service/start-acs-predix.sh
+++ b/service/start-acs-predix.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
 #*******************************************************************************
-# Copyright 2016 General Electric Company. 
+# Copyright 2016 General Electric Company.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 #*******************************************************************************
 
-export SPRING_PROFILES_ACTIVE='h2,predix,simple-cache'
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='h2,predix,simple-cache'
+fi
 export DIR=$( dirname "$( python -c "import os; print os.path.abspath('${BASH_SOURCE[0]}')" )" )
 source "${DIR}/start-acs.sh" "$@"

--- a/service/start-acs-public-titan.sh
+++ b/service/start-acs-public-titan.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 
 #*******************************************************************************
-# Copyright 2016 General Electric Company. 
+# Copyright 2016 General Electric Company.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 #*******************************************************************************
 
 unset PROXY_OPTS
-export SPRING_PROFILES_ACTIVE='h2,public,simple-cache,titan'
+
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='h2,public,simple-cache,titan'
+fi
 export DIR=$( dirname "$( python -c "import os; print os.path.abspath('${BASH_SOURCE[0]}')" )" )
 source "${DIR}/start-acs.sh" "$@"

--- a/service/start-acs-public.sh
+++ b/service/start-acs-public.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 
 #*******************************************************************************
-# Copyright 2016 General Electric Company. 
+# Copyright 2016 General Electric Company.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); 
-# you may not use this file except in compliance with the License. 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-# See the License for the specific language governing permissions and 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 #*******************************************************************************
 
 unset PROXY_OPTS
-export SPRING_PROFILES_ACTIVE='h2,public,simple-cache'
+
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE='h2,public,simple-cache'
+fi
 export DIR=$( dirname "$( python -c "import os; print os.path.abspath('${BASH_SOURCE[0]}')" )" )
 source "${DIR}/start-acs.sh" "$@"

--- a/service/start-acs.sh
+++ b/service/start-acs.sh
@@ -16,6 +16,14 @@
 # limitations under the License.
 #*******************************************************************************
 
+HTTP_VALIDATION_SPRING_PROFILE='httpValidation'
+if [[ -z "$SPRING_PROFILES_ACTIVE" ]]; then
+    export SPRING_PROFILES_ACTIVE="$HTTP_VALIDATION_SPRING_PROFILE"
+elif [[ "$SPRING_PROFILES_ACTIVE" != *"$HTTP_VALIDATION_SPRING_PROFILE"* ]]; then
+    export SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE},${HTTP_VALIDATION_SPRING_PROFILE}"
+fi
+echo "SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}"
+
 unset PORT_OFFSET
 source ./set-env-local.sh
 


### PR DESCRIPTION
 - Added an acceptance test for Accept header validation based on the 'httpValidation' Spring profile
 - Added the Spring profile to the list of active profiles for locally-run integration tests
 - Fixed enforcer-related dependency issues in the ACS integration test POM for the 'predix-local-titan' Maven profile
 - Added conditions to scripts that start ACS locally to only set the SPRING_PROFILES_ACTIVE environment variable if not already set